### PR TITLE
Removing php doc blocks

### DIFF
--- a/src/NullDev/Skeleton/Command/BroadwayCommandCliCommand.php
+++ b/src/NullDev/Skeleton/Command/BroadwayCommandCliCommand.php
@@ -28,9 +28,6 @@ class BroadwayCommandCliCommand extends BaseSkeletonGeneratorCommand
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/NullDev/Skeleton/Command/BroadwayDoctrineOrmReadCliCommand.php
+++ b/src/NullDev/Skeleton/Command/BroadwayDoctrineOrmReadCliCommand.php
@@ -37,9 +37,6 @@ class BroadwayDoctrineOrmReadCliCommand extends BaseSkeletonGeneratorCommand
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/NullDev/Skeleton/Command/BroadwayElasticSearchReadCliCommand.php
+++ b/src/NullDev/Skeleton/Command/BroadwayElasticSearchReadCliCommand.php
@@ -35,9 +35,6 @@ class BroadwayElasticSearchReadCliCommand extends BaseSkeletonGeneratorCommand
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/NullDev/Skeleton/Command/BroadwayEventCliCommand.php
+++ b/src/NullDev/Skeleton/Command/BroadwayEventCliCommand.php
@@ -28,9 +28,6 @@ class BroadwayEventCliCommand extends BaseSkeletonGeneratorCommand
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/NullDev/Skeleton/Command/BroadwayModelCliCommand.php
+++ b/src/NullDev/Skeleton/Command/BroadwayModelCliCommand.php
@@ -32,9 +32,6 @@ class BroadwayModelCliCommand extends BaseSkeletonGeneratorCommand
     }
 
     /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/NullDev/Skeleton/Definition/PHP/Methods/UuidCreateMethod.php
+++ b/src/NullDev/Skeleton/Definition/PHP/Methods/UuidCreateMethod.php
@@ -10,11 +10,6 @@ class UuidCreateMethod implements Method
 {
     private $classToBuild;
 
-    /**
-     * UuidCreateMethod constructor.
-     *
-     * @param $classToBuild
-     */
     public function __construct(ClassType $classToBuild)
     {
         $this->classToBuild = $classToBuild;

--- a/src/NullDev/Skeleton/Definition/PHP/Parameter.php
+++ b/src/NullDev/Skeleton/Definition/PHP/Parameter.php
@@ -19,25 +19,16 @@ class Parameter
         $this->classType = $classType;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return Type
-     */
     public function getClassType(): Type
     {
         return $this->classType;
     }
 
-    /**
-     * @return string
-     */
     public function getClassShortName(): string
     {
         return $this->getClassType()->getName();

--- a/src/NullDev/Skeleton/File/FileResource.php
+++ b/src/NullDev/Skeleton/File/FileResource.php
@@ -20,9 +20,6 @@ class FileResource
         $this->classSource = $classSource;
     }
 
-    /**
-     * @return ImprovedClassSource
-     */
     public function getClassSource(): ImprovedClassSource
     {
         return $this->classSource;

--- a/src/NullDev/Skeleton/Source/ImprovedClassSource.php
+++ b/src/NullDev/Skeleton/Source/ImprovedClassSource.php
@@ -32,19 +32,11 @@ class ImprovedClassSource
 
     private $imports = [];
 
-    /**
-     * ImprovedClassSource constructor.
-     *
-     * @param ClassType $classType
-     */
     public function __construct(ClassType $classType)
     {
         $this->classType = $classType;
     }
 
-    /**
-     * @return ClassType
-     */
     public function getClassType(): ClassType
     {
         return $this->classType;


### PR DESCRIPTION
In order to **remove visual debt**
For **developers** ,
We will **remove unhelpful param/return php doc blocks since we use types**
Whereas currently **it took screen space**