### PR TITLE
Task #101 Add FinderFactory

### DIFF
--- a/spec/NullDev/Skeleton/Path/Readers/FinderFactorySpec.php
+++ b/spec/NullDev/Skeleton/Path/Readers/FinderFactorySpec.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\NullDev\Skeleton\Path\Readers;
+
+use NullDev\Skeleton\Path\Readers\FinderFactory;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Finder\Finder;
+
+class FinderFactorySpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(FinderFactory::class);
+    }
+
+    public function it_will_return_new_instance_of_finder()
+    {
+        $this->create()->shouldReturnAnInstanceOf(Finder::class);
+    }
+}

--- a/src/NullDev/Nemesis/skeleton-services.yml
+++ b/src/NullDev/Nemesis/skeleton-services.yml
@@ -18,6 +18,8 @@ services:
   NullDev\Skeleton\SourceFactory\UuidIdentitySourceFactory: ~
   NullDev\Skeleton\File\FileFactory: ~
 
+  NullDev\Skeleton\Path\Readers\FinderFactory: ~
+
   NullDev\PhpSpecSkeleton\CodeGenerator\PhpParser\Methods\ExposeConstructorArgumentsAsGettersGenerator: ~
   NullDev\PhpSpecSkeleton\CodeGenerator\PhpParser\Methods\InitializableGenerator: ~
   NullDev\PhpSpecSkeleton\CodeGenerator\PhpParser\Methods\LetGenerator: ~

--- a/src/NullDev/Skeleton/Path/Readers/FinderFactory.php
+++ b/src/NullDev/Skeleton/Path/Readers/FinderFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Skeleton\Path\Readers;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @see FinderFactorySpec
+ * @see FinderFactoryTest
+ */
+class FinderFactory
+{
+    public function create(): Finder
+    {
+        return new Finder();
+    }
+}

--- a/tests/NullDev/Skeleton/Path/Readers/FinderFactoryTest.php
+++ b/tests/NullDev/Skeleton/Path/Readers/FinderFactoryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\NullDev\Skeleton\Path\Readers;
+
+use NullDev\Skeleton\Path\Readers\FinderFactory;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @covers \NullDev\Skeleton\Path\Readers\FinderFactory
+ * @group  unit
+ */
+class FinderFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreate()
+    {
+        $factory = new FinderFactory();
+
+        self::assertInstanceOf(Finder::class, $factory->create());
+    }
+}


### PR DESCRIPTION
In order to easily mock finder
For developers ,
We will create finder factory
Whereas currently we had to use real disk access to test classes like
SourceCodePathReader

 ## References
 
 Closes #101