### PR TITLE
Task #104 Define SourceCodePathReader as a service

### DIFF
--- a/src/NullDev/Nemesis/skeleton-services.yml
+++ b/src/NullDev/Nemesis/skeleton-services.yml
@@ -19,6 +19,7 @@ services:
   NullDev\Skeleton\File\FileFactory: ~
 
   NullDev\Skeleton\Path\Readers\FinderFactory: ~
+  NullDev\Skeleton\Path\Readers\SourceCodePathReader: ~
 
   NullDev\PhpSpecSkeleton\CodeGenerator\PhpParser\Methods\ExposeConstructorArgumentsAsGettersGenerator: ~
   NullDev\PhpSpecSkeleton\CodeGenerator\PhpParser\Methods\InitializableGenerator: ~

--- a/src/NullDev/Skeleton/Command/SimpleSkeletonGeneratorCommand.php
+++ b/src/NullDev/Skeleton/Command/SimpleSkeletonGeneratorCommand.php
@@ -112,7 +112,7 @@ abstract class SimpleSkeletonGeneratorCommand extends Command implements Contain
     protected function getExistingNamespaces(): array
     {
         if (null === $this->existingNamespaces) {
-            $this->existingNamespaces = (new SourceCodePathReader())->getExistingPaths($this->getPaths());
+            $this->existingNamespaces = $this->getService(SourceCodePathReader::class)->getExistingPaths($this->getPaths());
         }
 
         return $this->existingNamespaces;
@@ -121,7 +121,7 @@ abstract class SimpleSkeletonGeneratorCommand extends Command implements Contain
     protected function getExistingClasses(): array
     {
         if (null === $this->existingClasses) {
-            $this->existingClasses = (new SourceCodePathReader())->getExistingClasses($this->getPaths());
+            $this->existingClasses = $this->getService(SourceCodePathReader::class)->getExistingClasses($this->getPaths());
         }
 
         return $this->existingClasses;


### PR DESCRIPTION
In order to easily inject dependencies into SourceCodePathReader
For developers ,
We will define it as a service
Whereas currently we instantiate it manually

 ## References
 
 Closes #104