### PR TITLE
Generate missing PHPUnit tests

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -3,3 +3,12 @@ default:
         pretty:
             verbose:  true
             paths:    false
+            snippets: false
+    suites:
+        source_parser:
+            contexts:
+                - NullDev\Nemesis\SourceParserContext
+            filters:
+                tags: "@source_parser"
+
+

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,5 @@
+default:
+    formatters:
+        pretty:
+            verbose:  true
+            paths:    false

--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
         <exec command="phing -l" passthru="true"/>
     </target>
 
-    <target name="test" depends="phpspec,phpunit,fix-codestandards,phpstan"/>
+    <target name="test" depends="phpspec,phpunit,behat,fix-codestandards,phpstan"/>
 
     <target name="fix-codestandards" depends="php-cs-fixer-fix,phpmd,phpcs"/>
     <target name="check-codestandards" depends="php-cs-fixer-check,phpmd,phpcs"/>
@@ -24,11 +24,12 @@
     <target name="phpunit" description="Run phpunit">
         <exec command="vendor/bin/phpunit" passthru="true" checkreturn="true"/>
     </target>
+    <target name="behat" description="Run behat">
+        <exec command="vendor/bin/behat --strict" passthru="true" checkreturn="true"/>
+    </target>
     <target name="phpstan" description="Run phpstan">
         <exec command="vendor/bin/phpstan analyse -l 7 -c phpstan.neon src tests" passthru="true" checkreturn="true"/>
     </target>
-
-
 
     <target name="php-cs-fixer-check" description="Run php-cs-fixer check">
         <exec command="vendor/bin/php-cs-fixer fix --dry-run --diff" passthru="true" checkreturn="true"/>

--- a/circle.yml
+++ b/circle.yml
@@ -43,6 +43,26 @@ jobs:
       - store_test_results:
           path: build
 
+  behat:
+    docker:
+      - image: msvrtan/square:0.2.1
+    workDir: /var/www
+    steps:
+      - checkout
+      - restore_cache:
+          key: cache-v1-{{ checksum "composer.lock" }}
+      - run:
+          name: Composer install
+          command: composer install --no-interaction
+      - run:
+          name: PHPUnit
+          command: ./vendor/bin/behat
+      - type: artifacts-store
+        path: build
+        destination: build
+      - store_test_results:
+          path: build
+
   codestyle:
     docker:
       - image: msvrtan/square:0.2.1
@@ -130,6 +150,7 @@ workflows:
     jobs:
       - build
       - phpunit
+      - behat
       - codestyle
       - phpstan
       - humbug:

--- a/features/nemesis/source_parser/class-name.feature
+++ b/features/nemesis/source_parser/class-name.feature
@@ -1,0 +1,24 @@
+@source_parser
+Feature: Class name
+  In order to parse source code correctly
+  As a developer
+  I need to be sure class name is detected correctly
+
+  Scenario: Class inside namespace
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{}
+    """
+    When I parse it
+    Then result is an instance of "MyVendor\Something"
+
+  Scenario: Class doesnt have to be in a namespace
+    Given source file contains:
+    """
+    <?php
+    class Something{}
+    """
+    When I parse it
+    Then result is an instance of "Something"

--- a/features/nemesis/source_parser/constructor.feature
+++ b/features/nemesis/source_parser/constructor.feature
@@ -1,0 +1,156 @@
+@source_parser
+Feature: Constructor
+  In order to parse source code correctly
+  As a developer
+  I need to be sure constructor is properly parsed
+
+  Scenario: Class without defined constructor will have no constructor method defined
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{}
+    """
+    When I parse it
+    Then result has no constructor method defined
+
+
+  Scenario: Class with defined constructor will have constructor method defined
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(){}
+    }
+    """
+    When I parse it
+    Then result has constructor method defined
+
+
+  Scenario: Both constructor arguments without type will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct($param1,$param2){}
+    }
+    """
+    When I parse it
+    Then result has 2 constructor parameters
+    Then result will have this constructor parameters:
+      | className | name   |
+      |           | param1 |
+      |           | param2 |
+
+  Scenario: Constructor arguments will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(\DateTime $param1, MyValueObject $param2){}
+    }
+    """
+    When I parse it
+    Then result has 2 constructor parameters
+    Then result will have this constructor parameters:
+      | className                      | name   |
+      | DateTime                       | param1 |
+      | AnotherNamespace\MyValueObject | param2 |
+
+  Scenario: Nullable constructor arguments will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(?\DateTime $param1, ?MyValueObject $param2){}
+    }
+    """
+    When I parse it
+    Then result has 2 constructor parameters
+    Then result will have this constructor parameters:
+      | className                      | name   |
+      | DateTime                       | param1 |
+      | AnotherNamespace\MyValueObject | param2 |
+
+
+  Scenario: Scalar type constructor arguments will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(int $param1, string $param2, bool $param3, float $param4){}
+    }
+    """
+    When I parse it
+    Then result has 4 constructor parameters
+    Then result will have this constructor parameters:
+      | className | name   |
+      | int       | param1 |
+      | string    | param2 |
+      | bool      | param3 |
+      | float     | param4 |
+
+  Scenario: Nullable scalar type constructor arguments will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(?int $param1, ?string $param2, ?bool $param3, ?float $param4){}
+    }
+    """
+    When I parse it
+    Then result has 4 constructor parameters
+    Then result will have this constructor parameters:
+      | className | name   |
+      | int       | param1 |
+      | string    | param2 |
+      | bool      | param3 |
+      | float     | param4 |
+
+
+  Scenario: Array constructor arguments will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(array $param1){}
+    }
+    """
+    When I parse it
+    Then result has 1 constructor parameters
+    Then result will have this constructor parameters:
+      | className | name   |
+      | array     | param1 |
+
+  Scenario: Nullable array constructor arguments will be parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{
+        public function __construct(?array $param1){}
+    }
+    """
+    When I parse it
+    Then result has 1 constructor parameters
+    Then result will have this constructor parameters:
+      | className | name   |
+      | array     | param1 |
+
+

--- a/features/nemesis/source_parser/empty-files.feature
+++ b/features/nemesis/source_parser/empty-files.feature
@@ -1,0 +1,54 @@
+@source_parser
+Feature: Empty files
+  In order to parse source code correctly
+  As a developer
+  I need to be sure empty files return no results
+
+  Scenario: Empty file will give no results
+    Given source file contains:
+    """
+    """
+    When I parse it
+    Then result is an empty array
+
+  Scenario: Empty PHP file will give no results
+    Given source file contains:
+    """
+    <?php
+
+    """
+    When I parse it
+    Then result is an empty array
+
+  Scenario: File with only namespace will give no results
+    Given source file contains:
+    """
+    <?php
+    namespace Vendor\Something;
+    """
+    When I parse it
+    Then result is an empty array
+
+
+  Scenario: File without class definitions will give no results
+    Given source file contains:
+    """
+    <?php
+    namespace Vendor\Something;
+
+    $a = 1;
+    $b = 2;
+    echo $a + $b;
+    function myEcho($a){
+       echo $a.PHP_EOL;
+    }
+
+    myEcho($a);
+
+    """
+    When I parse it
+    Then result is an empty array
+
+
+
+

--- a/features/nemesis/source_parser/getter-methods.feature
+++ b/features/nemesis/source_parser/getter-methods.feature
@@ -1,0 +1,188 @@
+@source_parser
+Feature: Getter methods
+  In order to parse source code correctly
+  As a developer
+  I need to be sure getter methods are properly detected & parsed
+
+  Scenario: Class without any methods
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{}
+    """
+    When I parse it
+    Then result has 0 getter methods
+
+
+  Scenario: Class constructor is not getter
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      public function __construct(){}
+    }
+    """
+    When I parse it
+    Then result has 0 getter methods
+
+  Scenario: Some random function is not considered getter
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      public function doSomething(){}
+    }
+    """
+    When I parse it
+    Then result has 0 getter methods
+
+  Scenario: "Get" getter will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function __construct($a){}
+      public function getA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      |           | a            | getA       |
+
+  Scenario: "Is" getter for booleans will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function __construct($a){}
+      public function isA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      |           | a            | isA        |
+
+  Scenario: "Has" getter for booleans will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function __construct($a){}
+      public function hasA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      |           | a            | hasA       |
+
+
+  Scenario: None of the getters will be detected as there are no properties matching getter names
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      public function getA(){}
+      public function isB(){}
+      public function hasC(){}
+    }
+    """
+    When I parse it
+    Then result has 0 getter methods
+
+
+  Scenario: Class with constructor argument, property and getter defined will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function __constructor($a){}
+      public function getA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      |           | a            | getA       |
+
+
+  Scenario: Class with property and getter defined will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function getA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      |           | a            | getA       |
+
+  Scenario: It will detect property type from getters return type
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      private $b;
+      private $c;
+      public function getA() : \DateTime{}
+      public function isB() : bool{}
+      public function hasC() : bool{}
+    }
+    """
+    When I parse it
+    Then result has 3 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      | DateTime  | a            | getA       |
+      | bool      | b            | isB        |
+      | bool      | c            | hasC       |
+
+
+  Scenario: It will detect property type from constructor
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      private $b;
+      private $c;
+      public function __construct(\DateTime $a, bool $b, $c){}
+      public function getA(){}
+      public function isB(){}
+      public function hasC(){}
+    }
+    """
+    When I parse it
+    Then result has 3 getter methods
+    Then result will have this getterMethods:
+      | className | propertyName | getterName |
+      | DateTime  | a            | getA       |
+      | bool      | b            | isB        |
+      |           | c            | hasC       |
+

--- a/features/nemesis/source_parser/imports.feature
+++ b/features/nemesis/source_parser/imports.feature
@@ -1,0 +1,75 @@
+@source_parser
+Feature: Imports
+  In order to parse source code correctly
+  As a developer
+  I need to be sure all imports are correctly parsed
+
+  Scenario: Single imported class is correctly parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    class Something{}
+    """
+    When I parse it
+    Then result has 1 import
+    Then result will have this imports:
+      | className                      |
+      | AnotherNamespace\MyValueObject |
+
+
+  Scenario: Multiple imported class is correctly parsed
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject;
+    use AnotherNamespace\Money;
+    use AnotherNamespace\Currency;
+    use DateTime;
+    class Something{}
+    """
+    When I parse it
+    Then result has 4 imports
+    Then result will have this imports:
+      | className                      |
+      | AnotherNamespace\MyValueObject |
+      | AnotherNamespace\Money         |
+      | AnotherNamespace\Currency      |
+      | DateTime                       |
+
+
+  Scenario: Imports will work for class without namespaces too
+    Given source file contains:
+    """
+    <?php
+    use AnotherNamespace\MyValueObject;
+    use DateTime;
+    class Something{}
+    """
+    When I parse it
+    Then result has 2 imports
+    Then result will have this imports:
+      | className                      |
+      | AnotherNamespace\MyValueObject |
+      | DateTime                       |
+
+
+  @todo: maybe it shouldnt be?
+
+  Scenario: Import alias will be disregarded
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    use AnotherNamespace\MyValueObject as Money;
+    class Something{}
+    """
+    When I parse it
+    Then result has 1 import
+    Then result will have this imports:
+      | className                      |
+      | AnotherNamespace\MyValueObject |
+
+

--- a/features/nemesis/source_parser/methods.feature
+++ b/features/nemesis/source_parser/methods.feature
@@ -1,0 +1,67 @@
+@source_parser
+Feature: Methods
+  In order to parse source code correctly
+  As a developer
+  I need to be sure methods are properly detected & parsed
+
+  Scenario: Class without any methods
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{}
+    """
+    When I parse it
+    Then result has 0 methods
+
+
+  Scenario: Class with constructor will have 1 method
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      public function __construct(){}
+    }
+    """
+    When I parse it
+    Then result has 1 methods
+
+  Scenario: Getter will be detected correctly
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      public function getA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 methods
+
+  Scenario: "Is" getter for booleans will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function isA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 methods
+
+  Scenario: "Has" getter for booleans will be detected
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function hasA(){}
+    }
+    """
+    When I parse it
+    Then result has 1 methods
+

--- a/features/nemesis/source_parser/properties.feature
+++ b/features/nemesis/source_parser/properties.feature
@@ -1,0 +1,68 @@
+@source_parser
+Feature: Properties
+  In order to parse source code correctly
+  As a developer
+  I need to be sure properties are properly parsed
+
+  Scenario: Class without properties
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{}
+    """
+    When I parse it
+    Then result has 0 properties
+
+
+  Scenario: Class with properties of all visibilities
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      protected $b;
+      public $c;
+    }
+    """
+    When I parse it
+    Then result has 3 properties
+    Then result will have this properties:
+      | className | name |
+      |           | a    |
+      |           | b    |
+      |           | c    |
+
+  Scenario: Constructor arguments will not be added as property by default
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function __construct(\DateTime $b){}
+    }
+    """
+    When I parse it
+    Then result has 1 properties
+    Then result will have this properties:
+      | className | name |
+      |           | a    |
+
+
+  Scenario: Since there is a property and constructor argument of same name, add constructor argument as a property so we know the class
+    Given source file contains:
+    """
+    <?php
+    namespace MyVendor;
+    class Something{
+      private $a;
+      public function __construct(\DateTime $a){}
+    }
+    """
+    When I parse it
+    Then result has 1 properties
+    Then result will have this properties:
+      | className | name |
+      | DateTime  | a    |

--- a/spec/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestGetterGeneratorSpec.php
+++ b/spec/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestGetterGeneratorSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spec\NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods;
 
 use NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestGetterGenerator;
+use NullDev\Skeleton\CodeGenerator\MethodGenerator;
 use PhpParser\BuilderFactory;
 use PhpSpec\ObjectBehavior;
 
@@ -18,5 +19,6 @@ class TestGetterGeneratorSpec extends ObjectBehavior
     public function it_is_initializable()
     {
         $this->shouldHaveType(TestGetterGenerator::class);
+        $this->shouldImplement(MethodGenerator::class);
     }
 }

--- a/spec/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGeneratorSpec.php
+++ b/spec/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGeneratorSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods;
+
+use NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestSkippedGenerator;
+use NullDev\Skeleton\CodeGenerator\MethodGenerator;
+use PhpParser\BuilderFactory;
+use PhpSpec\ObjectBehavior;
+
+class TestSkippedGeneratorSpec extends ObjectBehavior
+{
+    public function let(BuilderFactory $builderFactory)
+    {
+        $this->beConstructedWith($builderFactory);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(TestSkippedGenerator::class);
+        $this->shouldImplement(MethodGenerator::class);
+    }
+}

--- a/spec/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestGetterMethodSpec.php
+++ b/spec/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestGetterMethodSpec.php
@@ -6,6 +6,7 @@ namespace spec\NullDev\PHPUnitSkeleton\Definition\PHP\Methods;
 
 use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestGetterMethod;
 use NullDev\Skeleton\Definition\PHP\Methods\GetterMethod;
+use NullDev\Skeleton\Definition\PHP\Methods\Method;
 use PhpSpec\ObjectBehavior;
 
 class TestGetterMethodSpec extends ObjectBehavior
@@ -18,6 +19,7 @@ class TestGetterMethodSpec extends ObjectBehavior
     public function it_is_initializable()
     {
         $this->shouldHaveType(TestGetterMethod::class);
+        $this->shouldImplement(Method::class);
     }
 
     public function it_has_no_method_parameters()

--- a/spec/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestSkippedMethodSpec.php
+++ b/spec/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestSkippedMethodSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\NullDev\PHPUnitSkeleton\Definition\PHP\Methods;
+
+use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestSkippedMethod;
+use NullDev\Skeleton\Definition\PHP\Methods\Method;
+use PhpSpec\ObjectBehavior;
+
+class TestSkippedMethodSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith($methodUnderTestName = 'doSomething');
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(TestSkippedMethod::class);
+        $this->shouldImplement(Method::class);
+    }
+
+    public function it_has_no_method_parameters()
+    {
+        $this->getParamsAsClassTypes()->shouldReturn([]);
+        $this->getMethodParameters()->shouldReturn([]);
+    }
+
+    public function it_is_a_public_method()
+    {
+        $this->getVisibility()->shouldReturn('public');
+    }
+
+    public function it_is_not_a_static_method()
+    {
+        $this->isStatic()->shouldReturn(false);
+    }
+
+    public function it_has_no_return_type()
+    {
+        $this->hasMethodReturnType()->shouldReturn(false);
+    }
+
+    public function it_throws_exception_if_asked_for_method_return_type()
+    {
+        $this->shouldThrow(\Exception::class)->duringGetMethodReturnType();
+    }
+
+    public function it_exposes_method_name()
+    {
+        $this->getMethodName()->shouldReturn('testDoSomething');
+    }
+}

--- a/spec/NullDev/Skeleton/File/FileFactorySpec.php
+++ b/spec/NullDev/Skeleton/File/FileFactorySpec.php
@@ -15,7 +15,7 @@ class FileFactorySpec extends ObjectBehavior
 {
     public function let(Config $config, Psr0Path $path1)
     {
-        $config->getPaths()->shouldBeCalled()->willReturn([$path1]);
+        $config->getPaths()->willReturn([$path1]);
         $this->beConstructedWith($config);
     }
 

--- a/spec/NullDev/Skeleton/Source/ImprovedClassSourceSpec.php
+++ b/spec/NullDev/Skeleton/Source/ImprovedClassSourceSpec.php
@@ -139,6 +139,7 @@ class ImprovedClassSourceSpec extends ObjectBehavior
         ClassType $paramClassType
     ) {
         $constructor->getMethodParameters()->willReturn([$param]);
+        $param->getName()->willReturn('paramName');
         $param->hasType()->willReturn(true);
         $param->getType()->willReturn($paramClassType);
 

--- a/src/Miro/First/AhaValueObject.php
+++ b/src/Miro/First/AhaValueObject.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miro\First;
+
+/**
+ * @see AhaValueObjectSpec
+ * @see AhaValueObjectTest
+ */
+class AhaValueObject
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var int
+     */
+    private $value;
+
+    public function __construct(string $name, int $value)
+    {
+        $this->name  = $name;
+        $this->value = $value;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+}

--- a/src/Miro/First/Currency.php
+++ b/src/Miro/First/Currency.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miro\First;
+
+/**
+ * @see CurrencySpec
+ * @see CurrencyTest
+ */
+class Currency
+{
+    /**
+     * @var string
+     */
+    private $code;
+
+    public function __construct(string $code)
+    {
+        $this->code = $code;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+}

--- a/src/Miro/First/Money.php
+++ b/src/Miro/First/Money.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miro\First;
+
+/**
+ * @see MoneySpec
+ * @see MoneyTest
+ */
+class Money
+{
+    /** @var int */
+    private $amount;
+    /** @var Currency */
+    private $currency;
+
+    public function __construct(int $amount, Currency $currency)
+    {
+        $this->amount   = $amount;
+        $this->currency = $currency;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency(): Currency
+    {
+        return $this->currency;
+    }
+}

--- a/src/Miro/First/MoneyConverter.php
+++ b/src/Miro/First/MoneyConverter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miro\First;
+
+/**
+ * @see MoneySpec
+ * @see MoneyTest
+ */
+class MoneyConverter
+{
+}

--- a/src/Miro/Second/Command/SomeCommand.php
+++ b/src/Miro/Second/Command/SomeCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miro\Second\Command;
+
+use Miro\First\Money;
+
+/**
+ * @see SomeCommandSpec
+ * @see SomeCommandTest
+ */
+class SomeCommand
+{
+    /**
+     * @var Money
+     */
+    private $money;
+
+    public function __construct(Money $money)
+    {
+        $this->money = $money;
+    }
+
+    public function getMoney(): Money
+    {
+        return $this->money;
+    }
+}

--- a/src/Miro/Second/Handler/SomeCommandHandler.php
+++ b/src/Miro/Second/Handler/SomeCommandHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Miro\Second\Handler;
+
+use Miro\First\MoneyConverter;
+use Miro\Second\Command\SomeCommand;
+
+/**
+ * @see SomeCommandHandlerSpec
+ * @see SomeCommandHandlerTest
+ */
+class SomeCommandHandler
+{
+    /** @var MoneyConverter */
+    private $moneyConverter;
+
+    public function __construct(MoneyConverter $moneyConverter)
+    {
+        $this->moneyConverter = $moneyConverter;
+    }
+
+    public function handle(SomeCommand $someCommand)
+    {
+        echo $someCommand->getMoney()->getAmount();
+    }
+}

--- a/src/NullDev/BroadwaySkeleton/Cli/BroadwayCommandCliCommand.php
+++ b/src/NullDev/BroadwaySkeleton/Cli/BroadwayCommandCliCommand.php
@@ -43,7 +43,7 @@ class BroadwayCommandCliCommand extends BaseSkeletonGeneratorCommand
         $className = $this->handleClassNameInput();
         $fields    = $this->getConstuctorParameters();
 
-        $classType    = ClassType::createFromFullyQualified($className);
+        $classType = ClassType::createFromFullyQualified($className);
 
         $command = new CreateBroadwayCommand($classType, $fields);
 

--- a/src/NullDev/BroadwaySkeleton/Cli/BroadwayEventCliCommand.php
+++ b/src/NullDev/BroadwaySkeleton/Cli/BroadwayEventCliCommand.php
@@ -44,7 +44,7 @@ class BroadwayEventCliCommand extends BaseSkeletonGeneratorCommand
         $className = $this->handleClassNameInput();
         $fields    = $this->getConstuctorParameters();
 
-        $classType    = ClassType::createFromFullyQualified($className);
+        $classType = ClassType::createFromFullyQualified($className);
 
         $command = new CreateBroadwayEvent($classType, $fields);
 

--- a/src/NullDev/BroadwaySkeleton/Cli/BroadwayModelCliCommand.php
+++ b/src/NullDev/BroadwaySkeleton/Cli/BroadwayModelCliCommand.php
@@ -48,9 +48,9 @@ class BroadwayModelCliCommand extends BaseSkeletonGeneratorCommand
 
         $generator = $this->getService(PhpParserGenerator::class);
 
-        $modelIdClassType       = ClassType::createFromFullyQualified($className.'Id');
-        $modelClassType         = ClassType::createFromFullyQualified($className.'Model');
-        $repositoryClassType    = ClassType::createFromFullyQualified($className.'Repository');
+        $modelIdClassType    = ClassType::createFromFullyQualified($className.'Id');
+        $modelClassType      = ClassType::createFromFullyQualified($className.'Model');
+        $repositoryClassType = ClassType::createFromFullyQualified($className.'Repository');
 
         $command = new CreateBroadwayModel($modelIdClassType, $modelClassType, $repositoryClassType);
 

--- a/src/NullDev/BroadwaySkeleton/Handler/CreateBroadwayEventHandler.php
+++ b/src/NullDev/BroadwaySkeleton/Handler/CreateBroadwayEventHandler.php
@@ -27,9 +27,9 @@ class CreateBroadwayEventHandler
         SpecGenerator $specGenerator,
         PHPUnitTestGenerator $unitTestGenerator
     ) {
-        $this->eventSourceFactory   = $eventSourceFactory;
-        $this->specGenerator        = $specGenerator;
-        $this->unitTestGenerator    = $unitTestGenerator;
+        $this->eventSourceFactory = $eventSourceFactory;
+        $this->specGenerator      = $specGenerator;
+        $this->unitTestGenerator  = $unitTestGenerator;
     }
 
     public function handle(CreateBroadwayEvent $command): array

--- a/src/NullDev/BroadwaySkeleton/Handler/CreateBroadwayModelHandler.php
+++ b/src/NullDev/BroadwaySkeleton/Handler/CreateBroadwayModelHandler.php
@@ -35,11 +35,11 @@ class CreateBroadwayModelHandler
         SpecGenerator $specGenerator,
         PHPUnitTestGenerator $unitTestGenerator
     ) {
-        $this->uuid4IdentitySourceFactory             = $uuid4IdentitySourceFactory;
-        $this->aggregateRootSourceFactory             = $aggregateRootSourceFactory;
-        $this->repositorySourceFactory                = $repositorySourceFactory;
-        $this->specGenerator                          = $specGenerator;
-        $this->unitTestGenerator                      = $unitTestGenerator;
+        $this->uuid4IdentitySourceFactory = $uuid4IdentitySourceFactory;
+        $this->aggregateRootSourceFactory = $aggregateRootSourceFactory;
+        $this->repositorySourceFactory    = $repositorySourceFactory;
+        $this->specGenerator              = $specGenerator;
+        $this->unitTestGenerator          = $unitTestGenerator;
     }
 
     public function handle(CreateBroadwayModel $command): array

--- a/src/NullDev/Nemesis/Command/GeneratePHPUnitTestsCliCommand.php
+++ b/src/NullDev/Nemesis/Command/GeneratePHPUnitTestsCliCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Nemesis\Command;
+
+use NullDev\Nemesis\Config\Config;
+use NullDev\Nemesis\SourceParser;
+use NullDev\PHPUnitSkeleton\PHPUnitTestGenerator;
+use NullDev\Skeleton\CodeGenerator\PhpParserGenerator;
+use NullDev\Skeleton\Command\ContainerImplementingTrait;
+use NullDev\Skeleton\Definition\PHP\Types\ClassType;
+use NullDev\Skeleton\File\FileFactory;
+use NullDev\Skeleton\Path\Readers\SourceCodePathReader;
+use NullDev\Skeleton\Source\ImprovedClassSource;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @codeCoverageIgnore
+ */
+class GeneratePHPUnitTestsCliCommand extends Command implements ContainerAwareInterface
+{
+    use ContainerImplementingTrait;
+
+    /** @var SymfonyStyle */
+    protected $io;
+
+    protected function configure()
+    {
+        $this->setName('generate:phpunit:missing')
+            ->setDescription('Generate missing PHPUnit test files');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->io = new SymfonyStyle($input, $output);
+
+        $reader = $this->getContainer()->get(SourceCodePathReader::class);
+
+        $sourceCodeClasses   = $reader->getSourceClasses($this->getConfig()->getSourceCodePaths());
+        $existingTestClasses = $reader->getTestClasses($this->getConfig()->getTestPaths());
+        $generator           = $this->getService(PhpParserGenerator::class);
+        $sourceParser        = $this->getService(SourceParser::class);
+
+        $generateTestClassSources = [];
+
+        foreach ($sourceCodeClasses as /*$sourceCodeClassName =>*/ $sourceCodeFile) {
+            $content = file_get_contents($sourceCodeFile->getRealPath());
+
+            $classSource = $sourceParser->parse($content)[0];
+
+            //$classType = ClassType::createFromFullyQualified($sourceCodeClassName);
+            //$classSource = new ImprovedClassSource($classType);
+
+            $testSource = $this->createPhpUnit5Source($classSource);
+
+            if (false === array_key_exists($testSource->getFullName(), $existingTestClasses)) {
+                $generateTestClassSources[] = $testSource;
+            }
+        }
+
+        foreach ($generateTestClassSources as $testSource) {
+            $fileName = $this->getFilePath($testSource);
+
+            $output = $generator->getOutput($testSource);
+            $this->handleGeneratingFile($fileName, $output);
+        }
+
+        $this->io->writeln('Done!');
+    }
+
+    private function createPhpUnit5Source(ImprovedClassSource $classSource): ImprovedClassSource
+    {
+        $generator = $this->getService(PHPUnitTestGenerator::class);
+
+        return $generator->generate($classSource);
+    }
+
+    private function getConfig(): Config
+    {
+        return $this->getService(Config::class);
+    }
+
+    private function getFilePath(ImprovedClassSource $classSource): string
+    {
+        return $this->getService(FileFactory::class)->getPath($classSource);
+    }
+
+    private function handleGeneratingFile(string $fileName, string $output): void
+    {
+        if ($this->fileNotExistsOrShouldBeOwerwritten($fileName)) {
+            $this->getService(Filesystem::class)->dumpFile($fileName, $output);
+
+            $this->io->writeln("Created '$fileName' file.");
+        } else {
+            $this->io->writeln("Skipped '$fileName' file.");
+        }
+    }
+
+    private function fileNotExistsOrShouldBeOwerwritten(string $fileName): bool
+    {
+        if (false === file_exists($fileName)) {
+            return true;
+        }
+
+        return $this->askOverwriteConfirmationQuestion($fileName);
+    }
+
+    private function askOverwriteConfirmationQuestion(string $fileName): bool
+    {
+        return $this->io->confirm("File '$fileName' exists, overwrite?", false);
+    }
+
+    protected function getSectionMessage(): string
+    {
+        return 'Generate missing PHPUnit tests';
+    }
+
+    protected function getIntroductionMessage(): array
+    {
+        return [
+            'This command helps you generate missing PHPUnit tests.',
+        ];
+    }
+}

--- a/src/NullDev/Nemesis/Config/ConfigFactory.php
+++ b/src/NullDev/Nemesis/Config/ConfigFactory.php
@@ -73,7 +73,7 @@ class ConfigFactory
                 'code'  => [
                     'src/' => '',
                 ],
-                'spec' => [
+                'spec'  => [
                     'spec/' => 'spec\\',
                 ],
                 'tests' => [

--- a/src/NullDev/Nemesis/SourceParser.php
+++ b/src/NullDev/Nemesis/SourceParser.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Nemesis;
+
+use NullDev\Skeleton\Definition\PHP\Methods\ConstructorMethod;
+use NullDev\Skeleton\Definition\PHP\Methods\GenericMethod;
+use NullDev\Skeleton\Definition\PHP\Methods\GetterMethod;
+use NullDev\Skeleton\Definition\PHP\Methods\Method;
+use NullDev\Skeleton\Definition\PHP\Parameter;
+use NullDev\Skeleton\Definition\PHP\Types\ClassType;
+use NullDev\Skeleton\Definition\PHP\Types\Type;
+use NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\ArrayType;
+use NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\BoolType;
+use NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\FloatType;
+use NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\IntType;
+use NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\StringType;
+use NullDev\Skeleton\Source\ImprovedClassSource;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+/**
+ * @see SourceParserSpec
+ * @see SourceParserTest
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings(PHPMD.CyclomaticComplexity)
+ * @SuppressWarnings(PHPMD.NPathComplexity)
+ */
+class SourceParser
+{
+    /**
+     * @var Parser
+     */
+    private $parser;
+    private $namespace;
+    private $class;
+    private $imports;
+
+    public function __construct()
+    {
+        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+    }
+
+    public function parse(string $code): array
+    {
+        $parsedStatements = $this->parser->parse($code);
+        $this->imports    = [];
+
+        $results = [];
+
+        foreach ($parsedStatements as $parsedStatement) {
+            if ($parsedStatement instanceof Namespace_) {
+                $results = array_merge($results, $this->parseNamespace($parsedStatement));
+            } elseif ($parsedStatement instanceof Class_) {
+                $results[] = $this->parseClass($parsedStatement, null);
+            } elseif ($parsedStatement instanceof Use_) {
+                $this->imports[] = ClassType::createFromFullyQualified((string) $parsedStatement->uses[0]->name);
+            }
+        }
+
+        foreach ($this->imports as $import) {
+            foreach ($results as $result) {
+                $result->addImport($import);
+            }
+        }
+
+        return $results;
+    }
+
+    private function parseNamespace(Namespace_ $namespaceStatement): array
+    {
+        $this->namespace = (string) $namespaceStatement->name;
+
+        $results = [];
+
+        foreach ($namespaceStatement->stmts as $parsedStatement) {
+            if ($parsedStatement instanceof Use_) {
+                $this->imports[] = ClassType::createFromFullyQualified((string) $parsedStatement->uses[0]->name);
+            }
+        }
+
+        foreach ($namespaceStatement->stmts as $parsedStatement) {
+            if ($parsedStatement instanceof Class_) {
+                $results[] = $this->parseClass($parsedStatement, $this->namespace);
+            }
+        }
+
+        return $results;
+
+        //die('TEMP DONE'.PHP_EOL.PHP_EOL.PHP_EOL);
+    }
+
+    private function parseClass(Class_ $classStatement, ?string $namespaceName): ImprovedClassSource
+    {
+        $className = (string) $classStatement->name;
+
+        //var_dump('classname:'.$className);
+
+        $this->class = new ImprovedClassSource(new ClassType($className, $namespaceName));
+
+        // Constructor parsing
+        foreach ($classStatement->stmts as $parsedStatement) {
+            if ($parsedStatement instanceof ClassMethod) {
+                $method = $this->parseMethod($parsedStatement);
+
+                if ($method instanceof ConstructorMethod) {
+                    $this->class->addConstructorMethod($method);
+                }
+            }
+        }
+
+        foreach ($classStatement->stmts as $parsedStatement) {
+            if ($parsedStatement instanceof Property) {
+                $propertyName = $parsedStatement->props[0]->name;
+
+                $property = new Parameter($propertyName);
+
+                // If constructor has param of same name, add that one as property since it has a class defined!
+                if (true === $this->class->hasConstructorMethod()) {
+                    foreach ($this->class->getConstructorParameters() as $constructorParameter) {
+                        if ($constructorParameter->getName() === $propertyName) {
+                            $property = $constructorParameter;
+                        }
+                    }
+                }
+
+                $this->class->addProperty($property);
+            }
+        }
+
+        //other methods
+
+        foreach ($classStatement->stmts as $parsedStatement) {
+            if ($parsedStatement instanceof ClassMethod) {
+                $method = $this->parseMethod($parsedStatement);
+
+                if (false === $method instanceof ConstructorMethod) {
+                    $this->class->addMethod($method);
+                }
+            }
+        }
+
+        return $this->class;
+    }
+
+    private function parseMethod(ClassMethod $classMethodStatement): Method
+    {
+        $methodName = $classMethodStatement->name;
+
+        //var_dump('method:'.$methodName);
+
+        if ('__construct' === $methodName) {
+            $params = [];
+
+            foreach ($classMethodStatement->params as $param) {
+                if ($param->type instanceof NullableType) {
+                    $typeName = (string) $param->type->type;
+                } else {
+                    $typeName = (string) $param->type;
+                }
+
+                $params[] = new Parameter($param->name, $this->createType($typeName));
+            }
+
+            $method = new ConstructorMethod($params);
+
+            return $method;
+        } elseif (0 === strpos($methodName, 'get')) {
+            $paramName = lcfirst(substr($methodName, 3));
+
+            return $this->createGetterMethod($paramName, $classMethodStatement);
+        } elseif (0 === strpos($methodName, 'is')) {
+            $paramName = lcfirst(substr($methodName, 2));
+
+            return $this->createGetterMethod($paramName, $classMethodStatement);
+        } elseif (0 === strpos($methodName, 'has')) {
+            $paramName = lcfirst(substr($methodName, 3));
+
+            return $this->createGetterMethod($paramName, $classMethodStatement);
+        }
+        $method = new GenericMethod($methodName, [], null);
+
+        return $method;
+    }
+
+    private function createGetterMethod(string $paramName, $classMethodStatement): Method
+    {
+        foreach ($this->class->getProperties() as $property) {
+            if ($property->getName() === $paramName) {
+                if ($classMethodStatement->returnType instanceof NullableType) {
+                    $returnTypeName = (string) $classMethodStatement->returnType->type;
+                } else {
+                    $returnTypeName = (string) $classMethodStatement->returnType;
+                }
+
+                $type = $this->createType($returnTypeName);
+
+                if (null === $type) {
+                    $param = $property;
+                } else {
+                    $param = new Parameter($paramName, $type);
+                }
+
+                $method = new GetterMethod($classMethodStatement->name, $param);
+
+                return $method;
+            }
+        }
+
+        $method = new GenericMethod($classMethodStatement->name, [], null);
+
+        return $method;
+    }
+
+    protected function createType(string $input): ?Type
+    {
+        $type = null;
+
+        if ('' === $input) {
+            $type = null;
+        } elseif ('string' === $input) {
+            $type = new StringType();
+        } elseif ('int' === $input) {
+            $type = new IntType();
+        } elseif ('float' === $input) {
+            $type = new FloatType();
+        } elseif ('array' === $input) {
+            $type = new ArrayType();
+        } elseif ('bool' === $input) {
+            $type = new BoolType();
+        } else {
+            foreach ($this->imports as $import) {
+                if ($import->getName() === $input) {
+                    return $import;
+                }
+            }
+
+            if (class_exists($input)) {
+                $type = ClassType::createFromFullyQualified($input);
+            } elseif (class_exists($this->namespace.'\\'.$input)) {
+                $type = ClassType::createFromFullyQualified($this->namespace.'\\'.$input);
+            } else {
+                throw new \Exception('Unknown class '.$input);
+            }
+        }
+
+        return $type;
+    }
+}

--- a/src/NullDev/Nemesis/SourceParserContext.php
+++ b/src/NullDev/Nemesis/SourceParserContext.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Nemesis;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use NullDev\Skeleton\Definition\PHP\Methods\GetterMethod;
+use NullDev\Skeleton\Source\ImprovedClassSource;
+use Webmozart\Assert\Assert;
+
+class SourceParserContext implements Context
+{
+    /** @var SourceParser */
+    private $sourceParser;
+    /** @var string */
+    private $input;
+    /** @var array */
+    private $result;
+
+    /**
+     * @When source file contains:
+     */
+    public function sourceFileContains(PyStringNode $input)
+    {
+        $this->input = $input->getRaw();
+    }
+
+    /**
+     * @When I parse it
+     */
+    public function iParseIt()
+    {
+        $this->sourceParser = new SourceParser();
+
+        $this->result = $this->sourceParser->parse($this->input);
+    }
+
+    /**
+     * @Then result is an empty array
+     */
+    public function resultIsAnEmptyArray()
+    {
+        Assert::isEmpty($this->result);
+    }
+
+    /**
+     * @Then result is an instance of :className
+     */
+    public function resultIsAnInstanceOf(string $className)
+    {
+        Assert::eq($className, $this->getResult()->getFullName());
+    }
+
+    /**
+     * @Then result has :count import
+     * @Then result has :count imports
+     */
+    public function resultHasImport(int $count)
+    {
+        Assert::count($this->getResult()->getImports(), $count);
+    }
+
+    /**
+     * @Then result will have this imports:
+     */
+    public function resultWillHaveThisImports(TableNode $table)
+    {
+        $imports = $this->getResult()->getImports();
+
+        $importClassNames = array_map(
+            function ($import) {
+                return $import->getFullName();
+            },
+            $imports
+        );
+
+        foreach ($table as $item) {
+            Assert::true(in_array($item['className'], $importClassNames));
+        }
+    }
+
+    /**
+     * @Then result has no constructor method defined
+     */
+    public function resultHasNoConstructorMethodDefined()
+    {
+        Assert::false($this->getResult()->hasConstructorMethod());
+    }
+
+    /**
+     * @Then result has constructor method defined
+     */
+    public function resultHasConstructorMethodDefined()
+    {
+        Assert::true($this->getResult()->hasConstructorMethod());
+    }
+
+    /**
+     * @Then result has :count constructor parameters
+     */
+    public function resultHasConstructorParameters(int $count)
+    {
+        Assert::count($this->getResult()->getConstructorParameters(), $count);
+    }
+
+    /**
+     * @Then result will have this constructor parameters:
+     */
+    public function resultWillHaveThisConstructorParameters($table)
+    {
+        $constructorParameters = $this->getResult()->getConstructorParameters();
+
+        foreach ($table as $key => $item) {
+            $param = $constructorParameters[$key];
+
+            if (true === empty($item['className'])) {
+                Assert::false($param->hasType());
+            } else {
+                Assert::eq($item['className'], $param->getType()->getFullName());
+            }
+
+            Assert::eq($item['name'], $param->getName());
+        }
+    }
+
+    /**
+     * @Then result has :count properties
+     */
+    public function resultHasProperties(int $count)
+    {
+        Assert::count($this->getResult()->getProperties(), $count);
+    }
+
+    /**
+     * @Then result will have this properties:
+     */
+    public function resultWillHaveThisProperties(TableNode $table)
+    {
+        $properties = $this->getResult()->getProperties();
+
+        foreach ($table as $key => $item) {
+            $param = $properties[$key];
+
+            if (true === empty($item['className'])) {
+                Assert::false($param->hasType());
+            } else {
+                Assert::eq($item['className'], $param->getType()->getFullName());
+            }
+
+            Assert::eq($item['name'], $param->getName());
+        }
+    }
+
+    /**
+     * @Then result has :count methods
+     */
+    public function resultHasMethods(int $count)
+    {
+        Assert::count($this->getResult()->getMethods(), $count);
+    }
+
+    /**
+     * @Then result has :count getter methods
+     */
+    public function resultHasGetterMethods(int $count)
+    {
+        $getterMethods = array_filter(
+            $this->getResult()->getMethods(),
+            function ($method) {
+                if ($method instanceof GetterMethod) {
+                    return true;
+                }
+
+                return false;
+            }
+        );
+        Assert::count($getterMethods, $count);
+    }
+
+    /**
+     * @Then result will have this getterMethods:
+     */
+    public function resultWillHaveThisGettermethods(TableNode $table)
+    {
+        $getterMethods = array_filter(
+            $this->getResult()->getMethods(),
+            function ($method) {
+                if ($method instanceof GetterMethod) {
+                    return true;
+                }
+
+                return false;
+            }
+        );
+
+        // Array filter preserves original keys :(
+        $getterMethods = array_values($getterMethods);
+
+        foreach ($table as $key => $item) {
+            $getterMethod = $getterMethods[$key];
+            Assert::eq($item['getterName'], $getterMethod->getMethodName());
+            Assert::eq($item['propertyName'], $getterMethod->getPropertyName());
+            if (true === empty($item['className'])) {
+                Assert::false($getterMethod->getParameter()->hasType());
+            } else {
+                Assert::eq($item['className'], $getterMethod->getParameter()->getType()->getFullName());
+            }
+        }
+    }
+
+    private function getResult(): ImprovedClassSource
+    {
+        return $this->result[0];
+    }
+}

--- a/src/NullDev/Nemesis/services.yml
+++ b/src/NullDev/Nemesis/services.yml
@@ -4,6 +4,11 @@ services:
     autoconfigure: true
     public: true
 
+  cli.command.nemesis.index:
+    class: NullDev\Nemesis\Command\GeneratePHPUnitTestsCliCommand
+    tags:
+      - {name: console.command }
+
   cli.command.nemesis.identity:
     class: NullDev\Skeleton\Uuid\Cli\Uuid4IdentityCommand
     tags:

--- a/src/NullDev/Nemesis/services.yml
+++ b/src/NullDev/Nemesis/services.yml
@@ -42,3 +42,5 @@ services:
 
 
   NullDev\Skeleton\Uuid\Handler\CreateUuidClassHandler: ~
+
+  NullDev\Nemesis\SourceParser: ~

--- a/src/NullDev/Nemesis/skeleton-services.yml
+++ b/src/NullDev/Nemesis/skeleton-services.yml
@@ -41,6 +41,7 @@ services:
   NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\SetUpGenerator: ~
   NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestGetterGenerator: ~
   NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestNothingGenerator: ~
+  NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestSkippedGenerator: ~
   NullDev\PHPUnitSkeleton\PHPUnitTestGenerator: ~
 
 

--- a/src/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGenerator.php
+++ b/src/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGenerator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods;
+
+use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestSkippedMethod;
+use NullDev\Skeleton\CodeGenerator\MethodGenerator;
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+
+/**
+ * @see TestSkippedGeneratorSpec
+ * @see TestSkippedGeneratorTest
+ */
+class TestSkippedGenerator implements MethodGenerator
+{
+    private $builderFactory;
+
+    public function __construct(BuilderFactory $builderFactory)
+    {
+        $this->builderFactory = $builderFactory;
+    }
+
+    public function supports($classMethod): bool
+    {
+        return $classMethod instanceof TestSkippedMethod;
+    }
+
+    public function generate(TestSkippedMethod $method)
+    {
+        $node = $this->builderFactory
+            ->method($method->getMethodName())
+            ->makePublic();
+
+        $node->addStmt(
+            new MethodCall(
+                new Variable('this'),
+                'markTestSkipped',
+                [
+                    new Arg(new String_('Skipping')),
+                ]
+            )
+        );
+
+        return $node;
+    }
+}

--- a/src/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestSkippedMethod.php
+++ b/src/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestSkippedMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\PHPUnitSkeleton\Definition\PHP\Methods;
+
+use NullDev\Skeleton\Definition\PHP\Methods\Method;
+
+/**
+ * @see TestSkippedMethodSpec
+ * @see TestSkippedMethodTest
+ */
+class TestSkippedMethod extends SimpleTestMethod implements Method
+{
+    /**
+     * @var string
+     */
+    private $methodUnderTestName;
+
+    public function __construct(string $methodUnderTestName)
+    {
+        $this->methodUnderTestName = $methodUnderTestName;
+    }
+
+    public function getMethodName(): string
+    {
+        return 'test'.ucfirst($this->methodUnderTestName);
+    }
+}

--- a/src/NullDev/PHPUnitSkeleton/PHPUnitTestGenerator.php
+++ b/src/NullDev/PHPUnitSkeleton/PHPUnitTestGenerator.php
@@ -85,6 +85,10 @@ class PHPUnitTestGenerator
             }
         }
 
+        if (1 === count($testSource->getMethods())) {
+            $testSource->addMethod(new TestNothingMethod($improvedClassSource));
+        }
+
         return $testSource;
     }
 }

--- a/src/NullDev/PHPUnitSkeleton/PHPUnitTestGenerator.php
+++ b/src/NullDev/PHPUnitSkeleton/PHPUnitTestGenerator.php
@@ -7,7 +7,10 @@ namespace NullDev\PHPUnitSkeleton;
 use NullDev\Nemesis\Config\Config;
 use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\SetUpMethod;
 use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestGetterMethod;
+use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestNothingMethod;
+use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestSkippedMethod;
 use NullDev\Skeleton\Definition\PHP\Methods\ConstructorMethod;
+use NullDev\Skeleton\Definition\PHP\Methods\GenericMethod;
 use NullDev\Skeleton\Definition\PHP\Methods\GetterMethod;
 use NullDev\Skeleton\Definition\PHP\Parameter;
 use NullDev\Skeleton\Definition\PHP\Types\ClassType;
@@ -20,6 +23,8 @@ use NullDev\Skeleton\Source\ImprovedClassSource;
 /**
  * @see PHPUnitTestGeneratorSpec
  * @see PHPUnitTestGeneratorTest
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class PHPUnitTestGenerator
 {
@@ -80,6 +85,8 @@ class PHPUnitTestGenerator
                 $testGetterMethod = new TestGetterMethod($method, lcfirst($improvedClassSource->getName()));
 
                 $testSource->addMethod($testGetterMethod);
+            } elseif ($method instanceof GenericMethod) {
+                $testSource->addMethod(new TestSkippedMethod($method->getMethodName()));
             } elseif ($method instanceof ConstructorMethod) {
                 continue;
             }

--- a/src/NullDev/PhpSpecSkeleton/CodeGenerator/PhpParser/Methods/ExposeGettersGenerator.php
+++ b/src/NullDev/PhpSpecSkeleton/CodeGenerator/PhpParser/Methods/ExposeGettersGenerator.php
@@ -65,7 +65,7 @@ class ExposeGettersGenerator implements MethodGenerator
                         ),
                         'shouldReturn',
                         [
-                        new Arg(new Variable($param->getName())),
+                            new Arg(new Variable($param->getName())),
                         ]
                     )
                 );

--- a/src/NullDev/Skeleton/Definition/PHP/DefinitionFactory.php
+++ b/src/NullDev/Skeleton/Definition/PHP/DefinitionFactory.php
@@ -60,7 +60,7 @@ class DefinitionFactory
         return new UuidCreateMethod($classType);
     }
 
-    public function createBroadwayModelCreateMethod(ClassType $classType, array  $parameters): CreateMethod
+    public function createBroadwayModelCreateMethod(ClassType $classType, array $parameters): CreateMethod
     {
         return new CreateMethod($classType, $parameters);
     }

--- a/src/NullDev/Skeleton/Definition/PHP/Methods/GenericMethod.php
+++ b/src/NullDev/Skeleton/Definition/PHP/Methods/GenericMethod.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Skeleton\Definition\PHP\Methods;
+
+use NullDev\Skeleton\Definition\PHP\Parameter;
+use NullDev\Skeleton\Definition\PHP\Types\ClassType;
+
+/**
+ * @see GenericMethodSpec
+ * @see GenericMethodTest
+ */
+class GenericMethod implements Method
+{
+    /** @var string */
+    private $methodName;
+    /** @var array|Parameter[] */
+    private $params;
+    /** @var null|ClassType */
+    private $returnType;
+
+    /**
+     * @param Parameter[] $params
+     */
+    public function __construct(string $methodName, array $params, ?ClassType $returnType)
+    {
+        $this->methodName = $methodName;
+        $this->params     = $params;
+        $this->returnType = $returnType;
+    }
+
+    public function getVisibility(): string
+    {
+        return 'public';
+    }
+
+    public function isStatic(): bool
+    {
+        return false;
+    }
+
+    public function getMethodName(): string
+    {
+        return $this->methodName;
+    }
+
+    /**
+     * @return Parameter[]
+     */
+    public function getMethodParameters(): array
+    {
+        return $this->params;
+    }
+
+    public function hasMethodReturnType(): bool
+    {
+        if (null === $this->returnType) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getMethodReturnType(): string
+    {
+        if (null === $this->returnType) {
+            throw new \Exception('Err 3415125125124: No return type defined');
+        }
+
+        return $this->returnType->getName();
+    }
+
+    /**
+     * @return Parameter[]
+     */
+    public function getParamsAsClassTypes(): array
+    {
+        $result = [];
+        foreach ($this->params as $param) {
+            if (true === $param->hasType()) {
+                $result[] = $param->getType();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/NullDev/Skeleton/File/FileFactory.php
+++ b/src/NullDev/Skeleton/File/FileFactory.php
@@ -9,12 +9,12 @@ use NullDev\Skeleton\Source\ImprovedClassSource;
 
 class FileFactory
 {
-    /** @var array */
-    private $paths;
+    /** @var Config */
+    private $config;
 
     public function __construct(Config $config)
     {
-        $this->paths = $config->getPaths();
+        $this->config = $config;
     }
 
     public function create(ImprovedClassSource $classSource): FileResource
@@ -24,7 +24,7 @@ class FileFactory
 
     protected function getPathItBelongsTo(ImprovedClassSource $classSource)
     {
-        foreach ($this->paths as $path) {
+        foreach ($this->config->getPaths() as $path) {
             if ($path->belongsTo($classSource->getFullName())) {
                 return $path;
             }

--- a/src/NullDev/Skeleton/Path/Readers/SourceCodePathReader.php
+++ b/src/NullDev/Skeleton/Path/Readers/SourceCodePathReader.php
@@ -30,7 +30,7 @@ class SourceCodePathReader
         $list = [];
         $iter = new ClassIterator($this->getPhpFiles2($paths));
 
-        foreach (array_keys($iter->getClassMap()) as $className) {
+        foreach ($iter->getClassMap() as $className => $path) {
             if (true === $this->isTestOrSpec($className)) {
                 continue;
             }
@@ -39,6 +39,7 @@ class SourceCodePathReader
                 $reflection = new \ReflectionClass($className);
             } catch (\Throwable $exception) {
                 echo $exception->getMessage();
+
                 continue;
             }
 
@@ -46,7 +47,7 @@ class SourceCodePathReader
                 continue;
             }
 
-            $list[$className] = $className;
+            $list[$className] = $path;
         }
 
         return $list;

--- a/src/NullDev/Skeleton/Source/ImprovedClassSource.php
+++ b/src/NullDev/Skeleton/Source/ImprovedClassSource.php
@@ -193,7 +193,6 @@ class ImprovedClassSource
             if (true === $parameter->hasType()) {
                 $this->addImportIfEligible($parameter->getType());
             }
-            //$this->addProperty($parameter);
         }
 
         $this->addMethod($constructor);

--- a/src/NullDev/Skeleton/Source/ImprovedClassSource.php
+++ b/src/NullDev/Skeleton/Source/ImprovedClassSource.php
@@ -196,11 +196,13 @@ class ImprovedClassSource
         }
 
         $this->addMethod($constructor);
+
         /*
                 foreach ($constructor->getMethodParameters() as $parameter) {
                     $this->addGetterMethod($parameter);
                 }
         */
+
         return $this;
     }
 

--- a/tests/NullDev/BroadwaySkeleton/CodeGenerator/BaseCodeGeneratorTest.php
+++ b/tests/NullDev/BroadwaySkeleton/CodeGenerator/BaseCodeGeneratorTest.php
@@ -120,7 +120,7 @@ abstract class BaseCodeGeneratorTest extends ContainerSupportedTestCase
         $parameters = [
             new Parameter('repository', ClassType::createFromFullyQualified('MyShop\\ReadModel\\Product\\ProductReadRepository')),
         ];
-        $factory    = new ElasticSearch\ReadProjectorSourceFactory(new ClassSourceFactory(), new DefinitionFactory());
+        $factory = new ElasticSearch\ReadProjectorSourceFactory(new ClassSourceFactory(), new DefinitionFactory());
 
         return $factory->create($classType, $parameters);
     }
@@ -169,7 +169,7 @@ abstract class BaseCodeGeneratorTest extends ContainerSupportedTestCase
             new Parameter('repository', ClassType::createFromFullyQualified('MyShop\\ReadModel\\Product\\ProductReadRepository')),
             new Parameter('factory', ClassType::createFromFullyQualified('MyShop\\ReadModel\\Product\\ProductReadFactory')),
         ];
-        $factory    = new DoctrineOrm\ReadProjectorSourceFactory(new ClassSourceFactory(), new DefinitionFactory());
+        $factory = new DoctrineOrm\ReadProjectorSourceFactory(new ClassSourceFactory(), new DefinitionFactory());
 
         return $factory->create($classType, $parameters);
     }

--- a/tests/NullDev/BroadwaySkeleton/CodeGenerator/PhpParser/Methods/SerializeGeneratorTest.php
+++ b/tests/NullDev/BroadwaySkeleton/CodeGenerator/PhpParser/Methods/SerializeGeneratorTest.php
@@ -14,7 +14,7 @@ use tests\NullDev\Skeleton\CodeGenerator\SeniorDeveloperProvider;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\CodeGenerator\PhpParser\Methods\SerializeGenerator
- * @group nemesis
+ * @group  nemesis
  */
 class SerializeGeneratorTest extends BaseOutputGeneratorTestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/AggregateRootIdGetterMethodTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/AggregateRootIdGetterMethodTest.php
@@ -12,7 +12,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\Definition\PHP\Methods\Model\AggregateRootIdGetterMethod
- * @group nemesis
+ * @group  nemesis
  */
 class AggregateRootIdGetterMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/CreateMethodTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/CreateMethodTest.php
@@ -10,7 +10,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\Definition\PHP\Methods\Model\CreateMethod
- * @group nemesis
+ * @group  nemesis
  */
 class CreateMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/ReadModelIdGetterMethodTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/ReadModelIdGetterMethodTest.php
@@ -12,7 +12,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\Definition\PHP\Methods\Model\ReadModelIdGetterMethod
- * @group nemesis
+ * @group  nemesis
  */
 class ReadModelIdGetterMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/RepositoryConstructorMethodTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Definition/PHP/Methods/Model/RepositoryConstructorMethodTest.php
@@ -10,7 +10,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\Definition\PHP\Methods\Model\RepositoryConstructorMethod
- * @group nemesis
+ * @group  nemesis
  */
 class RepositoryConstructorMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/Handler/CreateBroadwayDoctrineOrmReadHandlerTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Handler/CreateBroadwayDoctrineOrmReadHandlerTest.php
@@ -26,7 +26,7 @@ class CreateBroadwayDoctrineOrmReadHandlerTest extends ContainerSupportedTestCas
 
     public function setUp(): void
     {
-        $this->handler   = $this->getService(CreateBroadwayDoctrineOrmReadHandler::class);
+        $this->handler = $this->getService(CreateBroadwayDoctrineOrmReadHandler::class);
     }
 
     /**

--- a/tests/NullDev/BroadwaySkeleton/Handler/CreateBroadwayElasticSearchReadHandlerTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Handler/CreateBroadwayElasticSearchReadHandlerTest.php
@@ -26,7 +26,7 @@ class CreateBroadwayElasticSearchReadHandlerTest extends ContainerSupportedTestC
 
     public function setUp(): void
     {
-        $this->handler   = $this->getService(CreateBroadwayElasticSearchReadHandler::class);
+        $this->handler = $this->getService(CreateBroadwayElasticSearchReadHandler::class);
     }
 
     /**

--- a/tests/NullDev/BroadwaySkeleton/Handler/CreateBroadwayModelHandlerTest.php
+++ b/tests/NullDev/BroadwaySkeleton/Handler/CreateBroadwayModelHandlerTest.php
@@ -25,7 +25,7 @@ class CreateBroadwayModelHandlerTest extends ContainerSupportedTestCase
 
     public function setUp(): void
     {
-        $this->handler   = $this->getService(CreateBroadwayModelHandler::class);
+        $this->handler = $this->getService(CreateBroadwayModelHandler::class);
     }
 
     /**
@@ -33,9 +33,9 @@ class CreateBroadwayModelHandlerTest extends ContainerSupportedTestCase
      */
     public function testSourcesWillMatchExpectedOutput(string $className): void
     {
-        $modelIdClassType       = ClassType::createFromFullyQualified($className.'Id');
-        $modelClassType         = ClassType::createFromFullyQualified($className.'Model');
-        $repositoryClassType    = ClassType::createFromFullyQualified($className.'Repository');
+        $modelIdClassType    = ClassType::createFromFullyQualified($className.'Id');
+        $modelClassType      = ClassType::createFromFullyQualified($className.'Model');
+        $repositoryClassType = ClassType::createFromFullyQualified($className.'Repository');
 
         $command = new CreateBroadwayModel($modelIdClassType, $modelClassType, $repositoryClassType);
 

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayCommandHandlerTest/no-params/command-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayCommandHandlerTest/no-params/command-test.output
@@ -19,4 +19,8 @@ class CreateUserCommandTest extends PHPUnit_Framework_TestCase
     {
         $this->createUserCommand = new CreateUserCommand();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayDoctrineOrmReadHandlerTest/factory-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayDoctrineOrmReadHandlerTest/factory-test.output
@@ -19,4 +19,8 @@ class UserFactoryTest extends PHPUnit_Framework_TestCase
     {
         $this->userFactory = new UserFactory();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayDoctrineOrmReadHandlerTest/projector-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayDoctrineOrmReadHandlerTest/projector-test.output
@@ -23,4 +23,8 @@ class UserProjectorTest extends PHPUnit_Framework_TestCase
         $this->id = Mockery::mock(UserId::class);
         $this->userProjector = new UserProjector($this->id);
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayDoctrineOrmReadHandlerTest/repository-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayDoctrineOrmReadHandlerTest/repository-test.output
@@ -19,4 +19,8 @@ class UserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         $this->userRepository = new UserRepository();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayElasticSearchReadHandlerTest/projector-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayElasticSearchReadHandlerTest/projector-test.output
@@ -23,4 +23,8 @@ class UserProjectorTest extends PHPUnit_Framework_TestCase
         $this->id = Mockery::mock(UserId::class);
         $this->userProjector = new UserProjector($this->id);
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayElasticSearchReadHandlerTest/repository-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayElasticSearchReadHandlerTest/repository-test.output
@@ -19,4 +19,8 @@ class UserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         $this->userRepository = new UserRepository();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayEventHandlerTest/no-params/event-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayEventHandlerTest/no-params/event-test.output
@@ -19,4 +19,8 @@ class UserCreatedTest extends PHPUnit_Framework_TestCase
     {
         $this->userCreated = new UserCreated();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayModelHandlerTest/model-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayModelHandlerTest/model-test.output
@@ -19,4 +19,8 @@ class UserModelTest extends PHPUnit_Framework_TestCase
     {
         $this->userModel = new UserModel();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayModelHandlerTest/repository-test.output
+++ b/tests/NullDev/BroadwaySkeleton/Handler/sample-data/CreateBroadwayModelHandlerTest/repository-test.output
@@ -19,4 +19,8 @@ class UserRepositoryTest extends PHPUnit_Framework_TestCase
     {
         $this->userRepository = new UserRepository();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/CommandSourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/CommandSourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\CommandSourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class CommandSourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/EventSourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/EventSourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\EventSourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class EventSourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/EventSourcedAggregateRootSourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/EventSourcedAggregateRootSourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\EventSourcedAggregateRootSourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class EventSourcedAggregateRootSourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/EventSourcingRepositorySourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/EventSourcingRepositorySourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\EventSourcingRepositorySourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class EventSourcingRepositorySourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/DoctrineOrm/ReadEntitySourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/DoctrineOrm/ReadEntitySourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\Read\DoctrineOrm\ReadEntitySourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class ReadEntitySourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/DoctrineOrm/ReadFactorySourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/DoctrineOrm/ReadFactorySourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\Read\DoctrineOrm\ReadFactorySourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class ReadFactorySourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/DoctrineOrm/ReadProjectorSourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/DoctrineOrm/ReadProjectorSourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\Read\DoctrineOrm\ReadProjectorSourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class ReadProjectorSourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/ElasticSearch/ReadEntitySourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/ElasticSearch/ReadEntitySourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\Read\ElasticSearch\ReadEntitySourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class ReadEntitySourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/ElasticSearch/ReadProjectorSourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/ElasticSearch/ReadProjectorSourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\Read\ElasticSearch\ReadProjectorSourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class ReadProjectorSourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/ElasticSearch/ReadRepositorySourceFactoryTest.php
+++ b/tests/NullDev/BroadwaySkeleton/SourceFactory/Read/ElasticSearch/ReadRepositorySourceFactoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\BroadwaySkeleton\SourceFactory\Read\ElasticSearch\ReadRepositorySourceFactory
- * @group nemesis
+ * @group  nemesis
  */
 class ReadRepositorySourceFactoryTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestGetterGeneratorTest.php
+++ b/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestGetterGeneratorTest.php
@@ -16,7 +16,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestGetterGenerator
- * @group nemesis
+ * @group  nemesis
  */
 class TestGetterGeneratorTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestNothingGeneratorTest.php
+++ b/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestNothingGeneratorTest.php
@@ -13,7 +13,7 @@ use tests\NullDev\Skeleton\CodeGenerator\SeniorDeveloperProvider;
 
 /**
  * @covers \NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestNothingGenerator
- * @group nemesis
+ * @group  nemesis
  */
 class TestNothingGeneratorTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGeneratorTest.php
+++ b/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGeneratorTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestSkippedGenerator
- * @group nemesis
+ * @group  nemesis
  */
 class TestSkippedGeneratorTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGeneratorTest.php
+++ b/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/TestSkippedGeneratorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods;
+
+use NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestSkippedGenerator;
+use NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestSkippedMethod;
+use PhpParser\BuilderFactory;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \NullDev\PHPUnitSkeleton\CodeGenerator\PhpParser\Methods\TestSkippedGenerator
+ * @group nemesis
+ */
+class TestSkippedGeneratorTest extends PHPUnit_Framework_TestCase
+{
+    use OutputGeneratorTestTrait;
+
+    public function getGenerator(): TestSkippedGenerator
+    {
+        return new TestSkippedGenerator(new BuilderFactory());
+    }
+
+    /**
+     * @dataProvider provideParameters
+     */
+    public function testOutput(string $methodName, string $fileName): void
+    {
+        $method = new TestSkippedMethod($methodName);
+
+        $this->assertOutputMatches($method, $fileName);
+    }
+
+    public function provideParameters(): array
+    {
+        return [
+            [
+                'doSomething',
+                '0-no-param',
+            ],
+        ];
+    }
+}

--- a/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/sample-data/TestSkippedGeneratorTest/0-no-param.output
+++ b/tests/NullDev/PHPUnitSkeleton/CodeGenerator/PhpParser/Methods/sample-data/TestSkippedGeneratorTest/0-no-param.output
@@ -1,0 +1,6 @@
+<?php
+
+public function testDoSomething()
+{
+    $this->markTestSkipped('Skipping');
+}

--- a/tests/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/SetUpMethodTest.php
+++ b/tests/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/SetUpMethodTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PHPUnitSkeleton\Definition\PHP\Methods\SetUpMethod
- * @group nemesis
+ * @group  nemesis
  */
 class SetUpMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestNothingMethodTest.php
+++ b/tests/NullDev/PHPUnitSkeleton/Definition/PHP/Methods/TestNothingMethodTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PHPUnitSkeleton\Definition\PHP\Methods\TestNothingMethod
- * @group nemesis
+ * @group  nemesis
  */
 class TestNothingMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-all-multi.output
+++ b/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-all-multi.output
@@ -19,4 +19,8 @@ class SeniorTest extends PHPUnit_Framework_TestCase
     {
         $this->senior = new Senior();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-all.output
+++ b/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-all.output
@@ -19,4 +19,8 @@ class SeniorTest extends PHPUnit_Framework_TestCase
     {
         $this->senior = new Senior();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-interface.output
+++ b/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-interface.output
@@ -19,4 +19,8 @@ class SeniorTest extends PHPUnit_Framework_TestCase
     {
         $this->senior = new Senior();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-parent.output
+++ b/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-parent.output
@@ -19,4 +19,8 @@ class SeniorTest extends PHPUnit_Framework_TestCase
     {
         $this->senior = new Senior();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-trait.output
+++ b/tests/NullDev/PHPUnitSkeleton/example-outputs/class-with-trait.output
@@ -19,4 +19,8 @@ class SeniorTest extends PHPUnit_Framework_TestCase
     {
         $this->senior = new Senior();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/PHPUnitSkeleton/example-outputs/class.output
+++ b/tests/NullDev/PHPUnitSkeleton/example-outputs/class.output
@@ -19,4 +19,8 @@ class SeniorTest extends PHPUnit_Framework_TestCase
     {
         $this->senior = new Senior();
     }
+    public function testNothing()
+    {
+        $this->markTestIncomplete('Auto generated using nemesis');
+    }
 }

--- a/tests/NullDev/PhpSpecSkeleton/CodeGenerator/PhpParser/Methods/LetGeneratorTest.php
+++ b/tests/NullDev/PhpSpecSkeleton/CodeGenerator/PhpParser/Methods/LetGeneratorTest.php
@@ -18,7 +18,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PhpSpecSkeleton\CodeGenerator\PhpParser\Methods\LetGenerator
- * @group integration
+ * @group  integration
  */
 class LetGeneratorTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PhpSpecSkeleton/Definition/PHP/Methods/ExposeGettersMethodTest.php
+++ b/tests/NullDev/PhpSpecSkeleton/Definition/PHP/Methods/ExposeGettersMethodTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PhpSpecSkeleton\Definition\PHP\Methods\ExposeGettersMethod
- * @group nemesis
+ * @group  nemesis
  */
 class ExposeGettersMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PhpSpecSkeleton/Definition/PHP/Methods/InitializableMethodTest.php
+++ b/tests/NullDev/PhpSpecSkeleton/Definition/PHP/Methods/InitializableMethodTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PhpSpecSkeleton\Definition\PHP\Methods\InitializableMethod
- * @group nemesis
+ * @group  nemesis
  */
 class InitializableMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/PhpSpecSkeleton/Definition/PHP/Methods/LetMethodTest.php
+++ b/tests/NullDev/PhpSpecSkeleton/Definition/PHP/Methods/LetMethodTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\PhpSpecSkeleton\Definition\PHP\Methods\LetMethod
- * @group nemesis
+ * @group  nemesis
  */
 class LetMethodTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Definition/PHP/DocCommentTest.php
+++ b/tests/NullDev/Skeleton/Definition/PHP/DocCommentTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Definition\PHP\DocComment
- * @group unit
+ * @group  unit
  */
 class DocCommentTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/ArrayTypeTest.php
+++ b/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/ArrayTypeTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\ArrayType
- * @group unit
+ * @group  unit
  */
 class ArrayTypeTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/BoolTypeTest.php
+++ b/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/BoolTypeTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\BoolType
- * @group unit
+ * @group  unit
  */
 class BoolTypeTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/FloatTypeTest.php
+++ b/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/FloatTypeTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\FloatType
- * @group unit
+ * @group  unit
  */
 class FloatTypeTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/IntTypeTest.php
+++ b/tests/NullDev/Skeleton/Definition/PHP/Types/TypeDeclaration/IntTypeTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Definition\PHP\Types\TypeDeclaration\IntType
- * @group unit
+ * @group  unit
  */
 class IntTypeTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/File/FileResourceTest.php
+++ b/tests/NullDev/Skeleton/File/FileResourceTest.php
@@ -13,7 +13,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\File\FileResource
- * @group nemesis
+ * @group  nemesis
  */
 class FileResourceTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Path/SpecPsr0PathTest.php
+++ b/tests/NullDev/Skeleton/Path/SpecPsr0PathTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Path\SpecPsr0Path
- * @group unit
+ * @group  unit
  */
 class SpecPsr0PathTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Path/SpecPsr4PathTest.php
+++ b/tests/NullDev/Skeleton/Path/SpecPsr4PathTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Path\SpecPsr4Path
- * @group unit
+ * @group  unit
  */
 class SpecPsr4PathTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Path/TestPsr0PathTest.php
+++ b/tests/NullDev/Skeleton/Path/TestPsr0PathTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Path\TestPsr0Path
- * @group unit
+ * @group  unit
  */
 class TestPsr0PathTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/NullDev/Skeleton/Path/TestPsr4PathTest.php
+++ b/tests/NullDev/Skeleton/Path/TestPsr4PathTest.php
@@ -9,7 +9,7 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @covers \NullDev\Skeleton\Path\TestPsr4Path
- * @group unit
+ * @group  unit
  */
 class TestPsr4PathTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
In order to ease up development steps
For for developers ,
We will generate all missing PHPUnit tests
Whereas currently we do it manually

 ## References
 
 Closes #47