### PR TITLE
Define ContextName & ContextNamespace

### DIFF
--- a/spec/NullDev/Theater/BoundedContext/ContextNameSpec.php
+++ b/spec/NullDev/Theater/BoundedContext/ContextNameSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\NullDev\Theater\BoundedContext;
+
+use Exception;
+use NullDev\Theater\BoundedContext\ContextName;
+use PhpSpec\ObjectBehavior;
+
+class ContextNameSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith($name = 'LocalUser');
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ContextName::class);
+    }
+
+    public function it_exposes_name_via_get_value()
+    {
+        $this->getValue()->shouldReturn('LocalUser');
+    }
+
+    public function it_can_be_converted_to_string()
+    {
+        $this->__toString()->shouldReturn('LocalUser');
+    }
+
+    public function it_will_throw_exception_if_name_has_non_alphanumeric_characters()
+    {
+        $expectedException = new Exception('Name can use only alphanumeric characters.');
+
+        $this->shouldThrow($expectedException)->during('__construct', ['Something\User']);
+    }
+
+    public function it_will_throw_exception_if_empty_string_given()
+    {
+        $expectedException = new Exception('Name should not be empty.');
+
+        $this->shouldThrow($expectedException)->during('__construct', ['']);
+    }
+}

--- a/spec/NullDev/Theater/BoundedContext/ContextNamespaceSpec.php
+++ b/spec/NullDev/Theater/BoundedContext/ContextNamespaceSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\NullDev\Theater\BoundedContext;
+
+use Exception;
+use NullDev\Theater\BoundedContext\ContextNamespace;
+use PhpSpec\ObjectBehavior;
+
+class ContextNamespaceSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith($namespace = 'MyCompany\User\\');
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ContextNamespace::class);
+    }
+
+    public function it_exposes_namespace_via_get_value()
+    {
+        $this->getValue()->shouldReturn('MyCompany\User\\');
+    }
+
+    public function it_can_be_converted_to_string()
+    {
+        $this->__toString()->shouldReturn('MyCompany\User\\');
+    }
+
+    public function it_will_throw_exception_if_no_backslash_at_the_end_of_namespace()
+    {
+        $expectedException = new Exception('Namespace must end with \\.');
+
+        $this->shouldThrow($expectedException)->during('__construct', ['MyCompany\User']);
+    }
+
+    public function it_will_throw_exception_if_empty_string_given()
+    {
+        $expectedException = new Exception('Namespace should not be empty.');
+
+        $this->shouldThrow($expectedException)->during('__construct', ['']);
+    }
+}

--- a/src/NullDev/Theater/BoundedContext/ContextName.php
+++ b/src/NullDev/Theater/BoundedContext/ContextName.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Theater\BoundedContext;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @see ContextNameSpec
+ * @see ContextNameTest
+ */
+class ContextName
+{
+    /** @var string */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        Assert::notEmpty($name, 'Name should not be empty.');
+
+        Assert::alnum($name, 'Name can use only alphanumeric characters.');
+
+        $this->name = $name;
+    }
+
+    public function getValue(): string
+    {
+        return $this->name;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/NullDev/Theater/BoundedContext/ContextNamespace.php
+++ b/src/NullDev/Theater/BoundedContext/ContextNamespace.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Theater\BoundedContext;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @see ContextNamespaceSpec
+ * @see ContextNamespaceTest
+ */
+class ContextNamespace
+{
+    /** @var string */
+    private $namespace;
+
+    public function __construct(string $namespace)
+    {
+        Assert::notEmpty($namespace, 'Namespace should not be empty.');
+
+        Assert::true(substr($namespace, -1) === '\\', 'Namespace must end with \\.');
+
+        $this->namespace = $namespace;
+    }
+
+    public function getValue(): string
+    {
+        return $this->namespace;
+    }
+
+    public function __toString(): string
+    {
+        return $this->namespace;
+    }
+}

--- a/tests/NullDev/Theater/BoundedContext/ContextNameTest.php
+++ b/tests/NullDev/Theater/BoundedContext/ContextNameTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\NullDev\Theater\BoundedContext;
+
+use Exception;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use NullDev\Theater\BoundedContext\ContextName;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \NullDev\Theater\BoundedContext\ContextName
+ * @group  todo
+ */
+class ContextNameTest extends PHPUnit_Framework_TestCase
+{
+    use MockeryPHPUnitIntegration;
+    /** @var string */
+    private $name;
+    /** @var ContextName */
+    private $contextName;
+
+    public function setUp()
+    {
+        $this->name        = 'name';
+        $this->contextName = new ContextName($this->name);
+    }
+
+    public function testGetValue()
+    {
+        self::assertEquals($this->name, $this->contextName->getValue());
+    }
+
+    public function testToString()
+    {
+        self::assertEquals($this->name, $this->contextName->__toString());
+    }
+
+    /**
+     * @dataProvider provideBadContextNames
+     */
+    public function testDoesntAcceptName(string $name, string $expectedExceptionMessage)
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage($expectedExceptionMessage);
+
+        new ContextName($name);
+    }
+
+    public function provideBadContextNames(): array
+    {
+        return [
+            ['', 'Name should not be empty.'],
+            ['Something\User', 'Name can use only alphanumeric characters.'],
+            ['Something/User', 'Name can use only alphanumeric characters.'],
+        ];
+    }
+}

--- a/tests/NullDev/Theater/BoundedContext/ContextNamespaceTest.php
+++ b/tests/NullDev/Theater/BoundedContext/ContextNamespaceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\NullDev\Theater\BoundedContext;
+
+use Exception;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use NullDev\Theater\BoundedContext\ContextNamespace;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \NullDev\Theater\BoundedContext\ContextNamespace
+ * @group todo
+ */
+class ContextNamespaceTest extends PHPUnit_Framework_TestCase
+{
+    use MockeryPHPUnitIntegration;
+    /** @var string */
+    private $namespace;
+    /** @var ContextNamespace */
+    private $contextNamespace;
+
+    public function setUp()
+    {
+        $this->namespace        = 'MyCompany\SecretProject\Namespace\\';
+        $this->contextNamespace = new ContextNamespace($this->namespace);
+    }
+
+    public function testGetValue()
+    {
+        self::assertEquals($this->namespace, $this->contextNamespace->getValue());
+    }
+
+    public function testToString()
+    {
+        self::assertEquals($this->namespace, $this->contextNamespace->__toString());
+    }
+
+    /**
+     * @dataProvider provideBadContextNamespaces
+     */
+    public function testDoesntAcceptName(string $name, string $expectedExceptionMessage)
+    {
+        self::expectException(Exception::class);
+        self::expectExceptionMessage($expectedExceptionMessage);
+
+        new ContextNamespace($name);
+    }
+
+    public function provideBadContextNamespaces(): array
+    {
+        return [
+            ['', 'Namespace should not be empty.'],
+            ['Something\User', 'Namespace must end with \.'],
+        ];
+    }
+}


### PR DESCRIPTION
In order to define bounded contexts in Theater
For maintainers,
We will add value objects representing ContextName & ContextNamespace
Whereas we would be using simple strings

 ## References
 
 Closes #200