### PR TITLE
BUGFIX #224 ContextNamespace should not end with '\' to keep it consistent with other places in code

### DIFF
--- a/spec/NullDev/Theater/BoundedContext/BoundedContextConfigFactorySpec.php
+++ b/spec/NullDev/Theater/BoundedContext/BoundedContextConfigFactorySpec.php
@@ -57,7 +57,7 @@ class BoundedContextConfigFactorySpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($commandHanderClassName);
 
-        $this->create('Buyer', 'MyCompany\Webshop\Buyers\\')
+        $this->create('Buyer', 'MyCompany\Webshop\Buyers')
             ->shouldReturnAnInstanceOf(BoundedContextConfig::class);
     }
 }

--- a/spec/NullDev/Theater/BoundedContext/ContextNamespaceSpec.php
+++ b/spec/NullDev/Theater/BoundedContext/ContextNamespaceSpec.php
@@ -12,7 +12,7 @@ class ContextNamespaceSpec extends ObjectBehavior
 {
     public function let()
     {
-        $this->beConstructedWith($namespace = 'MyCompany\User\\');
+        $this->beConstructedWith($namespace = 'MyCompany\User');
     }
 
     public function it_is_initializable()
@@ -22,19 +22,19 @@ class ContextNamespaceSpec extends ObjectBehavior
 
     public function it_exposes_namespace_via_get_value()
     {
-        $this->getValue()->shouldReturn('MyCompany\User\\');
+        $this->getValue()->shouldReturn('MyCompany\User');
     }
 
     public function it_can_be_converted_to_string()
     {
-        $this->__toString()->shouldReturn('MyCompany\User\\');
+        $this->__toString()->shouldReturn('MyCompany\User');
     }
 
     public function it_will_throw_exception_if_no_backslash_at_the_end_of_namespace()
     {
-        $expectedException = new Exception('Namespace must end with \\.');
+        $expectedException = new Exception('Namespace must not end with \\.');
 
-        $this->shouldThrow($expectedException)->during('__construct', ['MyCompany\User']);
+        $this->shouldThrow($expectedException)->during('__construct', ['MyCompany\User\\']);
     }
 
     public function it_will_throw_exception_if_empty_string_given()

--- a/src/NullDev/Theater/BoundedContext/ContextNamespace.php
+++ b/src/NullDev/Theater/BoundedContext/ContextNamespace.php
@@ -19,7 +19,7 @@ class ContextNamespace
     {
         Assert::notEmpty($namespace, 'Namespace should not be empty.');
 
-        Assert::true(substr($namespace, -1) === '\\', 'Namespace must end with \\.');
+        Assert::false(substr($namespace, -1) === '\\', 'Namespace must not end with \\.');
 
         $this->namespace = $namespace;
     }

--- a/src/NullDev/Theater/NamingStrategy/TheaterNamingStrategy.php
+++ b/src/NullDev/Theater/NamingStrategy/TheaterNamingStrategy.php
@@ -87,17 +87,17 @@ class TheaterNamingStrategy implements NamingStrategy
 
     private function getCoreNamespace(): string
     {
-        return $this->getNamespace().'Core';
+        return $this->getNamespace().'\Core';
     }
 
     private function getDomainNamespace(): string
     {
-        return $this->getNamespace().'Domain';
+        return $this->getNamespace().'\Domain';
     }
 
     private function getApplicationNamespace(): string
     {
-        return $this->getNamespace().'Application';
+        return $this->getNamespace().'\Application';
     }
 
     private function getName(): string

--- a/tests/NullDev/Theater/BoundedContext/BoundedContextConfigFactoryTest.php
+++ b/tests/NullDev/Theater/BoundedContext/BoundedContextConfigFactoryTest.php
@@ -31,7 +31,7 @@ class BoundedContextConfigFactoryTest extends PHPUnit_Framework_TestCase
     public function testCreate()
     {
         $name      = 'Webshop';
-        $namespace = 'MyCompany\Webshop\\';
+        $namespace = 'MyCompany\Webshop';
 
         self::assertInstanceOf(
             BoundedContextConfig::class,

--- a/tests/NullDev/Theater/BoundedContext/ContextNamespaceTest.php
+++ b/tests/NullDev/Theater/BoundedContext/ContextNamespaceTest.php
@@ -23,7 +23,7 @@ class ContextNamespaceTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->namespace        = 'MyCompany\SecretProject\Namespace\\';
+        $this->namespace        = 'MyCompany\SecretProject\Namespace';
         $this->contextNamespace = new ContextNamespace($this->namespace);
     }
 
@@ -52,7 +52,7 @@ class ContextNamespaceTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['', 'Namespace should not be empty.'],
-            ['Something\User', 'Namespace must end with \.'],
+            ['Something\User\\', 'Namespace must not end with \.'],
         ];
     }
 }

--- a/tests/NullDev/Theater/NamingStrategy/NamingStrategyFactoryTest.php
+++ b/tests/NullDev/Theater/NamingStrategy/NamingStrategyFactoryTest.php
@@ -28,7 +28,7 @@ class NamingStrategyFactoryTest extends PHPUnit_Framework_TestCase
     {
         self::assertInstanceOf(
             TheaterNamingStrategy::class,
-            $this->factory->theater(new ContextName('Webshop'), new ContextNamespace('MyCompany\Webshop\\'))
+            $this->factory->theater(new ContextName('Webshop'), new ContextNamespace('MyCompany\Webshop'))
         );
     }
 }

--- a/tests/NullDev/Theater/NamingStrategy/TheaterNamingStrategyTest.php
+++ b/tests/NullDev/Theater/NamingStrategy/TheaterNamingStrategyTest.php
@@ -32,7 +32,7 @@ class TheaterNamingStrategyTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->contextName           = new ContextName('Webshop');
-        $this->contextNamespace      = new ContextNamespace('MyCompany\Webshop\\');
+        $this->contextNamespace      = new ContextNamespace('MyCompany\Webshop');
         $this->theaterNamingStrategy = new TheaterNamingStrategy($this->contextName, $this->contextNamespace);
     }
 


### PR DESCRIPTION
Closes #224