### PR TITLE
Add DevboardNamingStategy

### DIFF
--- a/spec/NullDev/Theater/NamingStrategy/DevboardNamingStrategySpec.php
+++ b/spec/NullDev/Theater/NamingStrategy/DevboardNamingStrategySpec.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\NullDev\Theater\NamingStrategy;
+
+use NullDev\Theater\BoundedContext\ContextName;
+use NullDev\Theater\BoundedContext\ContextNamespace;
+use NullDev\Theater\Naming\Aggregate\EntityClassName;
+use NullDev\Theater\Naming\Aggregate\RootIdClassName;
+use NullDev\Theater\Naming\Aggregate\RootModelClassName;
+use NullDev\Theater\Naming\Aggregate\RootRepositoryClassName;
+use NullDev\Theater\Naming\CommandClassName;
+use NullDev\Theater\Naming\CommandHandlerClassName;
+use NullDev\Theater\Naming\EventClassName;
+use NullDev\Theater\NamingStrategy\DevboardNamingStrategy;
+use NullDev\Theater\NamingStrategy\NamingStrategy;
+use PhpSpec\ObjectBehavior;
+
+class DevboardNamingStrategySpec extends ObjectBehavior
+{
+    public function let(ContextName $name, ContextNamespace $namespace)
+    {
+        $name->getValue()->willReturn('Webshop');
+        $namespace->getValue()->willReturn('MyCompany\Webshop\\');
+        $this->beConstructedWith($name, $namespace);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(DevboardNamingStrategy::class);
+        $this->shouldImplement(NamingStrategy::class);
+    }
+
+    public function it_should_name_aggregate_root_id_from_given_context_name_and_namespace()
+    {
+        $this->aggregateRootId()
+            ->shouldReturnAnInstanceOf(RootIdClassName::class);
+    }
+
+    public function it_should_name_aggregate_root_model_from_given_context_name_and_namespace()
+    {
+        $this->aggregateRootModel()
+            ->shouldReturnAnInstanceOf(RootModelClassName::class);
+    }
+
+    public function it_should_name_aggregate_root_repository_from_given_context_name_and_namespace()
+    {
+        $this->aggregateRootRepository()
+            ->shouldReturnAnInstanceOf(RootRepositoryClassName::class);
+    }
+
+    public function it_should_name_aggregate_entity()
+    {
+        $this->aggregateEntity('Something')
+            ->shouldReturnAnInstanceOf(EntityClassName::class);
+    }
+
+    public function it_should_name_command_handler_from_given_context_name_and_namespace()
+    {
+        $this->commandHandler()
+            ->shouldReturnAnInstanceOf(CommandHandlerClassName::class);
+    }
+
+    public function it_should_name_command()
+    {
+        $this->command('DoSomething')
+            ->shouldReturnAnInstanceOf(CommandClassName::class);
+    }
+
+    public function it_should_name_event()
+    {
+        $this->event('DidSomething')
+            ->shouldReturnAnInstanceOf(EventClassName::class);
+    }
+}

--- a/spec/NullDev/Theater/NamingStrategy/NamingStrategyFactorySpec.php
+++ b/spec/NullDev/Theater/NamingStrategy/NamingStrategyFactorySpec.php
@@ -6,6 +6,7 @@ namespace spec\NullDev\Theater\NamingStrategy;
 
 use NullDev\Theater\BoundedContext\ContextName;
 use NullDev\Theater\BoundedContext\ContextNamespace;
+use NullDev\Theater\NamingStrategy\DevboardNamingStrategy;
 use NullDev\Theater\NamingStrategy\NamingStrategyFactory;
 use NullDev\Theater\NamingStrategy\TheaterNamingStrategy;
 use PhpSpec\ObjectBehavior;
@@ -28,5 +29,13 @@ class NamingStrategyFactorySpec extends ObjectBehavior
     ) {
         $this->theater($contextName, $contextNamespace)
             ->shouldReturnAnInstanceOf(TheaterNamingStrategy::class);
+    }
+
+    public function it_will_create_devboard_naming_strategy_instance(
+        ContextName $contextName,
+        ContextNamespace $contextNamespace
+    ) {
+        $this->devboard($contextName, $contextNamespace)
+            ->shouldReturnAnInstanceOf(DevboardNamingStrategy::class);
     }
 }

--- a/src/NullDev/Theater/NamingStrategy/DevboardNamingStrategy.php
+++ b/src/NullDev/Theater/NamingStrategy/DevboardNamingStrategy.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NullDev\Theater\NamingStrategy;
+
+use NullDev\Theater\BoundedContext\ContextName;
+use NullDev\Theater\BoundedContext\ContextNamespace;
+use NullDev\Theater\Naming\Aggregate\EntityClassName;
+use NullDev\Theater\Naming\Aggregate\RootIdClassName;
+use NullDev\Theater\Naming\Aggregate\RootModelClassName;
+use NullDev\Theater\Naming\Aggregate\RootRepositoryClassName;
+use NullDev\Theater\Naming\CommandClassName;
+use NullDev\Theater\Naming\CommandHandlerClassName;
+use NullDev\Theater\Naming\EventClassName;
+
+/**
+ * @see DevboardNamingStrategySpec
+ * @see DevboardNamingStrategyTest
+ */
+class DevboardNamingStrategy implements NamingStrategy
+{
+    /** @var ContextName */
+    private $contextName;
+    /** @var ContextNamespace */
+    private $contextNamespace;
+
+    public function __construct(ContextName $contextName, ContextNamespace $contextNamespace)
+    {
+        $this->contextName      = $contextName;
+        $this->contextNamespace = $contextNamespace;
+    }
+
+    public function aggregateRootId(): RootIdClassName
+    {
+        $namespace = $this->getCoreNamespace();
+        $className = $this->getName().'Id';
+
+        return new RootIdClassName($className, $namespace);
+    }
+
+    public function aggregateRootModel(): RootModelClassName
+    {
+        $namespace = $this->getDomainNamespace();
+        $className = $this->getName().'Model';
+
+        return new RootModelClassName($className, $namespace);
+    }
+
+    public function aggregateRootRepository(): RootRepositoryClassName
+    {
+        $namespace = $this->getApplicationNamespace();
+        $className = $this->getName().'Repository';
+
+        return new RootRepositoryClassName($className, $namespace);
+    }
+
+    public function aggregateEntity(string $entityName): EntityClassName
+    {
+        $namespace = $this->getDomainNamespace();
+        $className = $entityName.'Entity';
+
+        return new EntityClassName($className, $namespace);
+    }
+
+    public function commandHandler(): CommandHandlerClassName
+    {
+        $namespace = $this->getApplicationNamespace();
+        $className = $this->getName().'CommandHandler';
+
+        return new CommandHandlerClassName($className, $namespace);
+    }
+
+    public function command(string $commandName): CommandClassName
+    {
+        $namespace = $this->getCoreNamespace().'\Command';
+
+        return new CommandClassName($commandName, $namespace);
+    }
+
+    public function event(string $eventName): EventClassName
+    {
+        $namespace = $this->getCoreNamespace().'\Event';
+
+        return new EventClassName($eventName, $namespace);
+    }
+
+    private function getCoreNamespace(): string
+    {
+        return $this->getNamespace().'\Core';
+    }
+
+    private function getDomainNamespace(): string
+    {
+        return $this->getNamespace().'\Domain';
+    }
+
+    private function getApplicationNamespace(): string
+    {
+        return $this->getNamespace().'\Application';
+    }
+
+    private function getName(): string
+    {
+        return $this->contextName->getValue();
+    }
+
+    private function getNamespace(): string
+    {
+        return $this->contextNamespace->getValue();
+    }
+}

--- a/src/NullDev/Theater/NamingStrategy/NamingStrategyFactory.php
+++ b/src/NullDev/Theater/NamingStrategy/NamingStrategyFactory.php
@@ -17,4 +17,9 @@ class NamingStrategyFactory
     {
         return new TheaterNamingStrategy($contextName, $contextNamespace);
     }
+
+    public function devboard(ContextName $contextName, ContextNamespace $contextNamespace): DevboardNamingStrategy
+    {
+        return new DevboardNamingStrategy($contextName, $contextNamespace);
+    }
 }

--- a/tests/NullDev/Theater/NamingStrategy/DevboardNamingStrategyTest.php
+++ b/tests/NullDev/Theater/NamingStrategy/DevboardNamingStrategyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\NullDev\Theater\NamingStrategy;
+
+use NullDev\Theater\BoundedContext\ContextName;
+use NullDev\Theater\BoundedContext\ContextNamespace;
+use NullDev\Theater\Naming\Aggregate\EntityClassName;
+use NullDev\Theater\Naming\Aggregate\RootIdClassName;
+use NullDev\Theater\Naming\Aggregate\RootModelClassName;
+use NullDev\Theater\Naming\Aggregate\RootRepositoryClassName;
+use NullDev\Theater\Naming\CommandClassName;
+use NullDev\Theater\Naming\CommandHandlerClassName;
+use NullDev\Theater\Naming\EventClassName;
+use NullDev\Theater\NamingStrategy\DevboardNamingStrategy;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \NullDev\Theater\NamingStrategy\DevboardNamingStrategy
+ * @group  unit
+ */
+class DevboardNamingStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /** @var DevboardNamingStrategy */
+    private $theaterNamingStrategy;
+    /** @var ContextName */
+    private $contextName;
+    /** @var ContextNamespace */
+    private $contextNamespace;
+
+    public function setUp()
+    {
+        $this->contextName           = new ContextName('Webshop');
+        $this->contextNamespace      = new ContextNamespace('MyCompany\Webshop');
+        $this->theaterNamingStrategy = new DevboardNamingStrategy($this->contextName, $this->contextNamespace);
+    }
+
+    public function testAggregateRootId()
+    {
+        $rootIdClassName = $this->theaterNamingStrategy->aggregateRootId();
+
+        self::assertInstanceOf(RootIdClassName::class, $rootIdClassName);
+
+        self::assertEquals('MyCompany\Webshop\Core\WebshopId', $rootIdClassName->getFullName());
+    }
+
+    public function testAggregateRootModel()
+    {
+        $rootModelClassName = $this->theaterNamingStrategy->aggregateRootModel();
+
+        self::assertInstanceOf(RootModelClassName::class, $rootModelClassName);
+
+        self::assertEquals('MyCompany\Webshop\Domain\WebshopModel', $rootModelClassName->getFullName());
+    }
+
+    public function testAggregateRootRepository()
+    {
+        $rootRepositoryClassName = $this->theaterNamingStrategy->aggregateRootRepository();
+
+        self::assertInstanceOf(RootRepositoryClassName::class, $rootRepositoryClassName);
+
+        self::assertEquals('MyCompany\Webshop\Application\WebshopRepository', $rootRepositoryClassName->getFullName());
+    }
+
+    public function testAggregateEntity()
+    {
+        $entityClassName = $this->theaterNamingStrategy->aggregateEntity('Something');
+
+        self::assertInstanceOf(EntityClassName::class, $entityClassName);
+
+        self::assertEquals('MyCompany\Webshop\Domain\SomethingEntity', $entityClassName->getFullName());
+    }
+
+    public function testCommandHandler()
+    {
+        $commandHandlerClassName = $this->theaterNamingStrategy->commandHandler();
+
+        self::assertInstanceOf(CommandHandlerClassName::class, $commandHandlerClassName);
+
+        self::assertEquals('MyCompany\Webshop\Application\WebshopCommandHandler', $commandHandlerClassName->getFullName());
+    }
+
+    public function testCommand()
+    {
+        $commandClassName = $this->theaterNamingStrategy->command('DoSomething');
+
+        self::assertInstanceOf(CommandClassName::class, $commandClassName);
+
+        self::assertEquals('MyCompany\Webshop\Core\Command\DoSomething', $commandClassName->getFullName());
+    }
+
+    public function testEvent()
+    {
+        $eventClassName = $this->theaterNamingStrategy->event('DidSomething');
+
+        self::assertInstanceOf(EventClassName::class, $eventClassName);
+
+        self::assertEquals('MyCompany\Webshop\Core\Event\DidSomething', $eventClassName->getFullName());
+    }
+}

--- a/tests/NullDev/Theater/NamingStrategy/NamingStrategyFactoryTest.php
+++ b/tests/NullDev/Theater/NamingStrategy/NamingStrategyFactoryTest.php
@@ -6,6 +6,7 @@ namespace tests\NullDev\Theater\NamingStrategy;
 
 use NullDev\Theater\BoundedContext\ContextName;
 use NullDev\Theater\BoundedContext\ContextNamespace;
+use NullDev\Theater\NamingStrategy\DevboardNamingStrategy;
 use NullDev\Theater\NamingStrategy\NamingStrategyFactory;
 use NullDev\Theater\NamingStrategy\TheaterNamingStrategy;
 use PHPUnit_Framework_TestCase;
@@ -29,6 +30,14 @@ class NamingStrategyFactoryTest extends PHPUnit_Framework_TestCase
         self::assertInstanceOf(
             TheaterNamingStrategy::class,
             $this->factory->theater(new ContextName('Webshop'), new ContextNamespace('MyCompany\Webshop'))
+        );
+    }
+
+    public function testDevboard()
+    {
+        self::assertInstanceOf(
+            DevboardNamingStrategy::class,
+            $this->factory->devboard(new ContextName('Webshop'), new ContextNamespace('MyCompany\Webshop'))
         );
     }
 }


### PR DESCRIPTION
In order to split possible dependencies better
For developers ,
We will add another naming strategy
Whereas currently we had only one

 ## References
 
 Closes #264